### PR TITLE
Chore: Add reviewer-assign.yml workflow

### DIFF
--- a/.github/workflows/reviewer-assign.yml
+++ b/.github/workflows/reviewer-assign.yml
@@ -1,0 +1,47 @@
+name: Reviewer Assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign reviewers and assignee
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const reviewers = ['nowybb', 'kiraywlee', 'yeonjelee', 'yeverycode', 'pxibvaw'];
+            
+            (async ({github, context}) => {
+              const prAuthor = context.actor;
+              const assignees = [prAuthor];
+
+              // 작성자를 reviewers 목록에서 제외
+              const filteredReviewers = reviewers.filter(r => r !== prAuthor);
+
+              const pullRequestNumber = context.payload.pull_request.number;
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
+
+              if (filteredReviewers.length > 0) {
+                await github.rest.pulls.requestReviewers({
+                  owner,
+                  repo,
+                  pull_number: pullRequestNumber,
+                  reviewers: filteredReviewers
+                });
+              }
+
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pullRequestNumber,
+                assignees
+              });
+            })({github, context});


### PR DESCRIPTION
PR 생성 시 Reviewer와 Assignee를 자동으로 지정하는 GitHub Actions 워크플로우(`.github/workflows/reviewer-assign.yml`)를 추가

- PR 작성자 → 자동 Assignee 지정
- 사전에 지정한 Reviewer 목록 중 작성자를 제외하고 자동 리뷰어 지정
