### PR TITLE
Feat : Precheck 페이지 추가 및 버튼 색상 전환 효과 구현 #8

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
+// File: src/App.js (또는 App.jsx)
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Common/Header';
 import BasicInfoPage from './pages/MyPage/BasicInfoPage';
 import CategorySelect from "./pages/Interview/CategorySelect";
 import InterviewPrep from './pages/InterviewPrep/InterviewPrepPage';
+import Precheck from './pages/Interview/Precheck';
 import InterviewSessionPage from './pages/Interview/InterviewSessionPage';
 import "./App.css";
 
@@ -14,11 +16,12 @@ function App() {
       <Header />
 
       {/* 페이지 라우팅 */}
-      <main>
+      <main className="app-main">
         <Routes>
           <Route path="/mypage" element={<BasicInfoPage />} />
           <Route path="/ai-interview" element={<CategorySelect />} />
           <Route path="/interview-prep" element={<InterviewPrep />} />
+          <Route path="/interview/precheck" element={<Precheck />} />
           <Route path="/interview/session" element={<InterviewSessionPage />} />
         </Routes>
       </main>

--- a/src/pages/Interview/CategorySelect.jsx
+++ b/src/pages/Interview/CategorySelect.jsx
@@ -56,8 +56,10 @@ export default function CategorySelect() {
       "최근 해결한 문제와 접근 방법은?",
       "협업 과정에서 갈등 해결 경험은?",
     ];
-    navigate("/interview/session", {
-      state: { job: `${selectedMajor}/${selectedMinor}`, questions },
+    navigate("/interview/precheck", {
+          state: { 
+            job: `${selectedMajor}/${selectedMinor}`, questions 
+           },
     });
   };
 

--- a/src/pages/Interview/Precheck.jsx
+++ b/src/pages/Interview/Precheck.jsx
@@ -1,0 +1,209 @@
+// File: src/pages/Interview/Precheck.jsx
+import React, { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import PageHero from "../../components/Common/PageHero";
+import styles from "./Precheck.module.css";
+
+const STATUS = {
+  idle: "idle",
+  ok: "ok",
+  fail: "fail",
+};
+
+export default function Precheck() {
+  const videoRef = useRef(null);
+  const camStreamRef = useRef(null);
+  const micStreamRef = useRef(null);
+  const analyserRef = useRef(null);
+  const rafRef = useRef(null);
+
+  const [camStatus, setCamStatus] = useState(STATUS.idle);
+  const [micStatus, setMicStatus] = useState(STATUS.idle);
+  const [checking, setChecking] = useState(false);
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { job, questions } = location.state || {};
+
+  const readyToStart = camStatus === STATUS.ok && micStatus === STATUS.ok;
+
+  useEffect(() => {
+    return () => stopAll();
+  }, []);
+
+  const stopAll = () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    [camStreamRef.current, micStreamRef.current].forEach((s) => {
+      if (s) s.getTracks().forEach((t) => t.stop());
+    });
+  };
+
+  const startCamera = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { width: 1280, height: 720 },
+        audio: false,
+      });
+      camStreamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play().catch(() => {});
+      }
+      setCamStatus(STATUS.ok);
+    } catch {
+      setCamStatus(STATUS.fail);
+    }
+  };
+
+  const startMicCheck = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+      micStreamRef.current = stream;
+
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      const source = ctx.createMediaStreamSource(stream);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 2048;
+      analyserRef.current = analyser;
+      source.connect(analyser);
+
+      const threshold = 0.02; // ~ -34dB
+      const endAt = performance.now() + 5000;
+      const data = new Uint8Array(analyser.frequencyBinCount);
+
+      const tick = () => {
+        analyser.getByteTimeDomainData(data);
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+          const v = (data[i] - 128) / 128;
+          sum += v * v;
+        }
+        const rms = Math.sqrt(sum / data.length);
+
+        if (rms > threshold) {
+          setMicStatus(STATUS.ok);
+          return;
+        }
+        if (performance.now() < endAt) {
+          rafRef.current = requestAnimationFrame(tick);
+        } else {
+          setMicStatus(STATUS.fail);
+        }
+      };
+      tick();
+    } catch {
+      setMicStatus(STATUS.fail);
+    }
+  };
+
+  const onStart = async () => {
+    setChecking(true);
+    setCamStatus(STATUS.idle);
+    setMicStatus(STATUS.idle);
+    stopAll();
+    await startCamera();
+    await startMicCheck();
+    setChecking(false);
+  };
+
+  const handleStartInterview = () => {
+    stopAll();
+    navigate("/interview/session", { state: { job, questions } });
+  };
+
+  // 상태별 배경색 매핑 (초록/빨강/회색)
+  const badgeClass = (st) =>
+    st === STATUS.ok
+      ? styles.badgeSuccess
+      : st === STATUS.fail
+      ? styles.badgeError
+      : styles.badgeIdle;
+
+  return (
+    <div className={styles.page}>
+      {/* 공통 배지 */}
+      <PageHero badge="응시환경 체크하기" />
+
+      {/* 안내문 + 시작하기 */}
+      <p className={styles.heroDesc}>
+        웹캠과 마이크 체크를 시작합니다.
+        <br />
+        <button
+          type="button"
+          className={`${styles.startBtn} ${styles.startBtnPrimary}`}
+          onClick={onStart}
+          disabled={checking}
+          aria-label="시작하기"
+        >
+          {checking && <span className={styles.spinner} aria-hidden="true" />}
+          {checking ? "확인 중..." : "시작하기"}
+        </button>{" "}
+        버튼을 누르고 가이드 선 안에 얼굴을 위치시켜
+        <br />“면접 테스트입니다.” 문구를 소리내어 읽어주세요.
+      </p>
+
+      {/* 메인 카드 */}
+      <section className={styles.card}>
+        <div className={styles.panel}>
+          {/* 좌: 웹캠 */}
+          <div className={styles.webcamWrap} aria-label="웹캠 미리보기">
+            <video ref={videoRef} className={styles.webcamVideo} autoPlay playsInline muted />
+          </div>
+
+          {/* 우: 상태 카드 */}
+          <div className={styles.statusCol}>
+            <div className={badgeClass(camStatus)}>
+              <div className={styles.badgeTitle}>
+                얼굴인식 {camStatus === STATUS.ok ? "성공" : camStatus === STATUS.fail ? "실패" : "대기"}
+              </div>
+              <div className={styles.badgeDesc}>
+                {camStatus === STATUS.ok
+                  ? "얼굴이 인식되었어요!"
+                  : camStatus === STATUS.fail
+                  ? "카메라가 감지되지 않아요."
+                  : "시작하기를 누르고 카메라 권한을 허용해 주세요."}
+              </div>
+              {camStatus === STATUS.ok && <span className={styles.checkIcon} aria-hidden="true">✓</span>}
+              {camStatus === STATUS.fail && <span className={styles.crossIcon} aria-hidden="true">✕</span>}
+            </div>
+
+            <div className={badgeClass(micStatus)}>
+              <div className={styles.badgeTitle}>
+                음성인식 {micStatus === STATUS.ok ? "성공" : micStatus === STATUS.fail ? "실패" : "대기"}
+              </div>
+              <div className={styles.badgeDesc}>
+                {micStatus === STATUS.ok
+                  ? "음성이 잘 들려요!"
+                  : micStatus === STATUS.fail
+                  ? "음성이 제대로 들리지 않아요."
+                  : "“면접 테스트입니다.”라고 말해 주세요."}
+              </div>
+              {micStatus === STATUS.ok && <span className={styles.checkIcon} aria-hidden="true">✓</span>}
+              {micStatus === STATUS.fail && <span className={styles.crossIcon} aria-hidden="true">✕</span>}
+            </div>
+          </div>
+        </div>
+
+        {/* 하단 액션 */}
+        <div style={{ textAlign: "center", marginTop: 20 }}>
+          <button
+            type="button"
+            className={`${styles.startBtn} ${styles.startBtnPrimary}`}
+            onClick={handleStartInterview}
+            disabled={!readyToStart}
+          >
+            {readyToStart ? "면접 시작하기" : "환경 확인 필요"}
+          </button>
+          {!readyToStart && (
+            <div style={{ marginTop: 8, fontSize: 14, color: "#7a7f8c" }}>
+              카메라와 마이크가 모두 정상이어야 시작할 수 있어요.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Interview/Precheck.module.css
+++ b/src/pages/Interview/Precheck.module.css
@@ -1,0 +1,215 @@
+/* -------------------------------------------
+   File: src/pages/Interview/Precheck.module.css
+   - 공통 PageHero(.page-hero__badge) 사용
+   - 안내문/카드/웹캠/상태 뱃지 UI 개선
+-------------------------------------------- */
+
+/* 배지 아래 안내문 */
+.heroDesc {
+  max-width: 560px;
+  margin: 8px auto 0;
+  text-align: center;
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 26px;
+  color: #111;
+}
+
+/* 베이스 */
+.startBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid #7a7f8c;
+  background: #fff;
+  font-size: 15px;
+  color: #111;
+  cursor: pointer;
+  transition: background .15s ease, box-shadow .15s ease, transform .04s ease;
+}
+/* 베이스 hover는 '프라이머리/소프트'가 아닐 때만 적용 */
+.startBtn:not(.startBtnPrimary):not(.startBtnSoft):hover { background: #f5f6f8; }
+.startBtn:active { transform: translateY(1px); }
+.startBtn:disabled { opacity: .55; cursor: default; }
+
+/* (A) 부드러운 소프트 버튼 – 페이지 톤과 잘 섞임 */
+.startBtnSoft {
+  background: #EFF3FA;             /* 아주 옅은 네이비 톤 */
+  border-color: #D6DEEE;
+  color: #1F2A44;
+}
+.startBtnSoft:hover {
+  background: #E8EEF8;             /* 살짝만 진하게 */
+  box-shadow: 0 6px 16px rgba(31,42,68,0.08);
+}
+.startBtnSoft:active { transform: translateY(0); }
+.startBtnSoft:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #fff, 0 0 0 6px rgba(31,42,68,0.25);
+}
+
+/* 강조 버전(하단 '면접 시작하기'에 사용) */
+.startBtnSoftEmph {
+  background: #E6EEFF;
+  border-color: #BFD0FF;
+  color: #1F2A44;
+  font-weight: 600;
+}
+.startBtnSoftEmph:hover {
+  background: #DDE7FF;
+  box-shadow: 0 8px 18px rgba(31,42,68,0.12);
+}
+
+/* 기본 프라이머리 버튼 (하늘 → 파랑 그라디언트) */
+.startBtnPrimary {
+  border: none;
+  background: linear-gradient(180deg, #ABD7FA 0%, #79BEFB 100%);
+  color: #3B375A;
+  padding: 5px 15px;
+  font-weight: 600;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 8px 20px rgba(127, 119, 186, 0.25);
+}
+
+/* hover 시 살짝 진하게 */
+.startBtnPrimary:hover {
+  background: linear-gradient(180deg, #9CCFF9 0%, #6EB6F9 100%);
+  box-shadow: 0 10px 24px rgba(127, 119, 186, 0.32);
+}
+
+/* active 시 (누를 때) 남색 배경 + 흰색 글씨 */
+.startBtnPrimary:active {
+  background: #2F2B4A;
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(47, 43, 74, 0.28);
+}
+
+/* 포커스 시 시각적 강조 */
+.startBtnPrimary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #fff, 0 0 0 6px rgba(47, 43, 74, 0.55);
+}
+
+/* 스피너 – 소프트 버튼에 어울리도록 다크 톤 */
+.spinner {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border: 2px solid rgba(31,42,68,0.25);
+  border-top-color: #1F2A44;
+  border-radius: 50%;
+  animation: spin .9s linear infinite;
+  display: inline-block;
+  vertical-align: -3px;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+
+/* 메인 카드(흰 직사각형) */
+.card {
+  width: 100%;
+  max-width: 1312px;
+  margin: 28px auto 0;
+  background: #fff;
+  border-radius: 20px;
+  padding: 40px 40px 48px;
+  box-shadow: 0 6px 24px rgba(22,34,66,.06);
+  box-sizing: border-box;
+}
+
+/* 좌우 레이아웃 */
+.panel {
+  display: grid;
+  grid-template-columns: 1fr 0.95fr;  /* 우측 살짝 좁게 */
+  gap: 28px;
+}
+@media (max-width: 1100px) { .panel { grid-template-columns: 1fr; } }
+
+/* 웹캠 */
+.webcamWrap {
+  height: 380px;
+  border: 1px solid #000;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #000;
+}
+.webcamVideo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* 우측 상태 컬럼 */
+.statusCol {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: 24px;
+}
+
+/* 상태 배지 공통 */
+.badgeIdle,
+.badgeSuccess,
+.badgeError {
+  position: relative;
+  border-radius: 18px;
+  padding: 22px 56px 22px 24px; /* 우측 아이콘 공간 */
+  min-height: 168px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  box-sizing: border-box;
+  transition: box-shadow .2s ease;
+}
+.badgeIdle:hover, .badgeSuccess:hover, .badgeError:hover {
+  box-shadow: 0 6px 18px rgba(19,43,84,.08);
+}
+
+/* 성공(초록) / 실패(빨강) / 대기(회색) */
+.badgeSuccess { background:#E8F8EF; border:1px solid #34D46A; } /* 초록 */
+.badgeError   { background:#FFF0F0; border:1px solid #FF4154; } /* 빨강 */
+.badgeIdle    { background:#F6F7F9; border:1px solid #E4E7EC; } /* 회색 */
+
+/* 텍스트 */
+.badgeTitle {
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 28px;
+  color: #4a4f59;
+  margin-bottom: 6px;
+}
+.badgeDesc {
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 26px;
+  color: #666;
+}
+
+/* 아이콘(✓ / ✕) */
+.checkIcon, .crossIcon {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: #fff;
+}
+.checkIcon { background:#34D46A; } /* 초록 */
+.crossIcon { background:#FF4154; } /* 빨강 */
+
+/* 모바일 */
+@media (max-width: 600px) {
+  .heroDesc { font-size: 16px; line-height: 24px; }
+  .badgeTitle { font-size: 20px; }
+  .badgeDesc { font-size: 16px; }
+  .card { padding: 24px; }
+}


### PR DESCRIPTION
## 작업 내용
- Precheck 페이지 신규 추가
  - 카메라·마이크 권한 요청 및 환경 체크 기능 구현
  - 인식 성공 시 초록색 UI, 실패 시 빨간색 UI 적용
- 시작하기 버튼 UI 업그레이드
  - 기본: 하늘색 그라디언트 (#ABD7FA → #79BEFB)
  - 클릭 시: 남색 배경 + 흰색 글씨 전환
- App.js에 Precheck 라우트 추가

## 변경 사항
- App.js 라우트 등록
- CategorySelect.jsx, InterviewSessionPage.jsx 연결 수정
- Precheck.jsx, Precheck.module.css 신규 생성

## 관련 이슈
Closes #8 

<img width="1283" height="742" alt="스크린샷 2025-08-12 오후 1 23 47" src="https://github.com/user-attachments/assets/0b366d38-82c3-4530-802e-14b4cc6bcb5e" />
