### PR TITLE
Feat: 마이페이지 탭 개편 및 내 활동(자소서/스크랩/면접기록) 구현 #10

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
+// File: src/App.js (또는 App.jsx)
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Common/Header';
 import BasicInfoPage from './pages/MyPage/BasicInfoPage';
 import CategorySelect from "./pages/Interview/CategorySelect";
 import InterviewPrep from './pages/InterviewPrep/InterviewPrepPage';
+import Precheck from './pages/Interview/Precheck';
 import InterviewSessionPage from './pages/Interview/InterviewSessionPage';
 import "./App.css";
 
@@ -14,11 +16,12 @@ function App() {
       <Header />
 
       {/* 페이지 라우팅 */}
-      <main>
+      <main className="app-main">
         <Routes>
           <Route path="/mypage" element={<BasicInfoPage />} />
           <Route path="/ai-interview" element={<CategorySelect />} />
           <Route path="/interview-prep" element={<InterviewPrep />} />
+          <Route path="/interview/precheck" element={<Precheck />} />
           <Route path="/interview/session" element={<InterviewSessionPage />} />
         </Routes>
       </main>

--- a/src/pages/Interview/CategorySelect.jsx
+++ b/src/pages/Interview/CategorySelect.jsx
@@ -56,8 +56,10 @@ export default function CategorySelect() {
       "최근 해결한 문제와 접근 방법은?",
       "협업 과정에서 갈등 해결 경험은?",
     ];
-    navigate("/interview/session", {
-      state: { job: `${selectedMajor}/${selectedMinor}`, questions },
+    navigate("/interview/precheck", {
+          state: { 
+            job: `${selectedMajor}/${selectedMinor}`, questions 
+           },
     });
   };
 

--- a/src/pages/Interview/Precheck.jsx
+++ b/src/pages/Interview/Precheck.jsx
@@ -1,0 +1,209 @@
+// File: src/pages/Interview/Precheck.jsx
+import React, { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import PageHero from "../../components/Common/PageHero";
+import styles from "./Precheck.module.css";
+
+const STATUS = {
+  idle: "idle",
+  ok: "ok",
+  fail: "fail",
+};
+
+export default function Precheck() {
+  const videoRef = useRef(null);
+  const camStreamRef = useRef(null);
+  const micStreamRef = useRef(null);
+  const analyserRef = useRef(null);
+  const rafRef = useRef(null);
+
+  const [camStatus, setCamStatus] = useState(STATUS.idle);
+  const [micStatus, setMicStatus] = useState(STATUS.idle);
+  const [checking, setChecking] = useState(false);
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { job, questions } = location.state || {};
+
+  const readyToStart = camStatus === STATUS.ok && micStatus === STATUS.ok;
+
+  useEffect(() => {
+    return () => stopAll();
+  }, []);
+
+  const stopAll = () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    [camStreamRef.current, micStreamRef.current].forEach((s) => {
+      if (s) s.getTracks().forEach((t) => t.stop());
+    });
+  };
+
+  const startCamera = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { width: 1280, height: 720 },
+        audio: false,
+      });
+      camStreamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play().catch(() => {});
+      }
+      setCamStatus(STATUS.ok);
+    } catch {
+      setCamStatus(STATUS.fail);
+    }
+  };
+
+  const startMicCheck = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+      micStreamRef.current = stream;
+
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      const source = ctx.createMediaStreamSource(stream);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 2048;
+      analyserRef.current = analyser;
+      source.connect(analyser);
+
+      const threshold = 0.02; // ~ -34dB
+      const endAt = performance.now() + 5000;
+      const data = new Uint8Array(analyser.frequencyBinCount);
+
+      const tick = () => {
+        analyser.getByteTimeDomainData(data);
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+          const v = (data[i] - 128) / 128;
+          sum += v * v;
+        }
+        const rms = Math.sqrt(sum / data.length);
+
+        if (rms > threshold) {
+          setMicStatus(STATUS.ok);
+          return;
+        }
+        if (performance.now() < endAt) {
+          rafRef.current = requestAnimationFrame(tick);
+        } else {
+          setMicStatus(STATUS.fail);
+        }
+      };
+      tick();
+    } catch {
+      setMicStatus(STATUS.fail);
+    }
+  };
+
+  const onStart = async () => {
+    setChecking(true);
+    setCamStatus(STATUS.idle);
+    setMicStatus(STATUS.idle);
+    stopAll();
+    await startCamera();
+    await startMicCheck();
+    setChecking(false);
+  };
+
+  const handleStartInterview = () => {
+    stopAll();
+    navigate("/interview/session", { state: { job, questions } });
+  };
+
+  // 상태별 배경색 매핑 (초록/빨강/회색)
+  const badgeClass = (st) =>
+    st === STATUS.ok
+      ? styles.badgeSuccess
+      : st === STATUS.fail
+      ? styles.badgeError
+      : styles.badgeIdle;
+
+  return (
+    <div className={styles.page}>
+      {/* 공통 배지 */}
+      <PageHero badge="응시환경 체크하기" />
+
+      {/* 안내문 + 시작하기 */}
+      <p className={styles.heroDesc}>
+        웹캠과 마이크 체크를 시작합니다.
+        <br />
+        <button
+          type="button"
+          className={`${styles.startBtn} ${styles.startBtnPrimary}`}
+          onClick={onStart}
+          disabled={checking}
+          aria-label="시작하기"
+        >
+          {checking && <span className={styles.spinner} aria-hidden="true" />}
+          {checking ? "확인 중..." : "시작하기"}
+        </button>{" "}
+        버튼을 누르고 가이드 선 안에 얼굴을 위치시켜
+        <br />“면접 테스트입니다.” 문구를 소리내어 읽어주세요.
+      </p>
+
+      {/* 메인 카드 */}
+      <section className={styles.card}>
+        <div className={styles.panel}>
+          {/* 좌: 웹캠 */}
+          <div className={styles.webcamWrap} aria-label="웹캠 미리보기">
+            <video ref={videoRef} className={styles.webcamVideo} autoPlay playsInline muted />
+          </div>
+
+          {/* 우: 상태 카드 */}
+          <div className={styles.statusCol}>
+            <div className={badgeClass(camStatus)}>
+              <div className={styles.badgeTitle}>
+                얼굴인식 {camStatus === STATUS.ok ? "성공" : camStatus === STATUS.fail ? "실패" : "대기"}
+              </div>
+              <div className={styles.badgeDesc}>
+                {camStatus === STATUS.ok
+                  ? "얼굴이 인식되었어요!"
+                  : camStatus === STATUS.fail
+                  ? "카메라가 감지되지 않아요."
+                  : "시작하기를 누르고 카메라 권한을 허용해 주세요."}
+              </div>
+              {camStatus === STATUS.ok && <span className={styles.checkIcon} aria-hidden="true">✓</span>}
+              {camStatus === STATUS.fail && <span className={styles.crossIcon} aria-hidden="true">✕</span>}
+            </div>
+
+            <div className={badgeClass(micStatus)}>
+              <div className={styles.badgeTitle}>
+                음성인식 {micStatus === STATUS.ok ? "성공" : micStatus === STATUS.fail ? "실패" : "대기"}
+              </div>
+              <div className={styles.badgeDesc}>
+                {micStatus === STATUS.ok
+                  ? "음성이 잘 들려요!"
+                  : micStatus === STATUS.fail
+                  ? "음성이 제대로 들리지 않아요."
+                  : "“면접 테스트입니다.”라고 말해 주세요."}
+              </div>
+              {micStatus === STATUS.ok && <span className={styles.checkIcon} aria-hidden="true">✓</span>}
+              {micStatus === STATUS.fail && <span className={styles.crossIcon} aria-hidden="true">✕</span>}
+            </div>
+          </div>
+        </div>
+
+        {/* 하단 액션 */}
+        <div style={{ textAlign: "center", marginTop: 20 }}>
+          <button
+            type="button"
+            className={`${styles.startBtn} ${styles.startBtnPrimary}`}
+            onClick={handleStartInterview}
+            disabled={!readyToStart}
+          >
+            {readyToStart ? "면접 시작하기" : "환경 확인 필요"}
+          </button>
+          {!readyToStart && (
+            <div style={{ marginTop: 8, fontSize: 14, color: "#7a7f8c" }}>
+              카메라와 마이크가 모두 정상이어야 시작할 수 있어요.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Interview/Precheck.module.css
+++ b/src/pages/Interview/Precheck.module.css
@@ -1,0 +1,215 @@
+/* -------------------------------------------
+   File: src/pages/Interview/Precheck.module.css
+   - 공통 PageHero(.page-hero__badge) 사용
+   - 안내문/카드/웹캠/상태 뱃지 UI 개선
+-------------------------------------------- */
+
+/* 배지 아래 안내문 */
+.heroDesc {
+  max-width: 560px;
+  margin: 8px auto 0;
+  text-align: center;
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 26px;
+  color: #111;
+}
+
+/* 베이스 */
+.startBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid #7a7f8c;
+  background: #fff;
+  font-size: 15px;
+  color: #111;
+  cursor: pointer;
+  transition: background .15s ease, box-shadow .15s ease, transform .04s ease;
+}
+/* 베이스 hover는 '프라이머리/소프트'가 아닐 때만 적용 */
+.startBtn:not(.startBtnPrimary):not(.startBtnSoft):hover { background: #f5f6f8; }
+.startBtn:active { transform: translateY(1px); }
+.startBtn:disabled { opacity: .55; cursor: default; }
+
+/* (A) 부드러운 소프트 버튼 – 페이지 톤과 잘 섞임 */
+.startBtnSoft {
+  background: #EFF3FA;             /* 아주 옅은 네이비 톤 */
+  border-color: #D6DEEE;
+  color: #1F2A44;
+}
+.startBtnSoft:hover {
+  background: #E8EEF8;             /* 살짝만 진하게 */
+  box-shadow: 0 6px 16px rgba(31,42,68,0.08);
+}
+.startBtnSoft:active { transform: translateY(0); }
+.startBtnSoft:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #fff, 0 0 0 6px rgba(31,42,68,0.25);
+}
+
+/* 강조 버전(하단 '면접 시작하기'에 사용) */
+.startBtnSoftEmph {
+  background: #E6EEFF;
+  border-color: #BFD0FF;
+  color: #1F2A44;
+  font-weight: 600;
+}
+.startBtnSoftEmph:hover {
+  background: #DDE7FF;
+  box-shadow: 0 8px 18px rgba(31,42,68,0.12);
+}
+
+/* 기본 프라이머리 버튼 (하늘 → 파랑 그라디언트) */
+.startBtnPrimary {
+  border: none;
+  background: linear-gradient(180deg, #ABD7FA 0%, #79BEFB 100%);
+  color: #3B375A;
+  padding: 5px 15px;
+  font-weight: 600;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 8px 20px rgba(127, 119, 186, 0.25);
+}
+
+/* hover 시 살짝 진하게 */
+.startBtnPrimary:hover {
+  background: linear-gradient(180deg, #9CCFF9 0%, #6EB6F9 100%);
+  box-shadow: 0 10px 24px rgba(127, 119, 186, 0.32);
+}
+
+/* active 시 (누를 때) 남색 배경 + 흰색 글씨 */
+.startBtnPrimary:active {
+  background: #2F2B4A;
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(47, 43, 74, 0.28);
+}
+
+/* 포커스 시 시각적 강조 */
+.startBtnPrimary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #fff, 0 0 0 6px rgba(47, 43, 74, 0.55);
+}
+
+/* 스피너 – 소프트 버튼에 어울리도록 다크 톤 */
+.spinner {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border: 2px solid rgba(31,42,68,0.25);
+  border-top-color: #1F2A44;
+  border-radius: 50%;
+  animation: spin .9s linear infinite;
+  display: inline-block;
+  vertical-align: -3px;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+
+/* 메인 카드(흰 직사각형) */
+.card {
+  width: 100%;
+  max-width: 1312px;
+  margin: 28px auto 0;
+  background: #fff;
+  border-radius: 20px;
+  padding: 40px 40px 48px;
+  box-shadow: 0 6px 24px rgba(22,34,66,.06);
+  box-sizing: border-box;
+}
+
+/* 좌우 레이아웃 */
+.panel {
+  display: grid;
+  grid-template-columns: 1fr 0.95fr;  /* 우측 살짝 좁게 */
+  gap: 28px;
+}
+@media (max-width: 1100px) { .panel { grid-template-columns: 1fr; } }
+
+/* 웹캠 */
+.webcamWrap {
+  height: 380px;
+  border: 1px solid #000;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #000;
+}
+.webcamVideo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* 우측 상태 컬럼 */
+.statusCol {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: 24px;
+}
+
+/* 상태 배지 공통 */
+.badgeIdle,
+.badgeSuccess,
+.badgeError {
+  position: relative;
+  border-radius: 18px;
+  padding: 22px 56px 22px 24px; /* 우측 아이콘 공간 */
+  min-height: 168px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  box-sizing: border-box;
+  transition: box-shadow .2s ease;
+}
+.badgeIdle:hover, .badgeSuccess:hover, .badgeError:hover {
+  box-shadow: 0 6px 18px rgba(19,43,84,.08);
+}
+
+/* 성공(초록) / 실패(빨강) / 대기(회색) */
+.badgeSuccess { background:#E8F8EF; border:1px solid #34D46A; } /* 초록 */
+.badgeError   { background:#FFF0F0; border:1px solid #FF4154; } /* 빨강 */
+.badgeIdle    { background:#F6F7F9; border:1px solid #E4E7EC; } /* 회색 */
+
+/* 텍스트 */
+.badgeTitle {
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 28px;
+  color: #4a4f59;
+  margin-bottom: 6px;
+}
+.badgeDesc {
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 26px;
+  color: #666;
+}
+
+/* 아이콘(✓ / ✕) */
+.checkIcon, .crossIcon {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: #fff;
+}
+.checkIcon { background:#34D46A; } /* 초록 */
+.crossIcon { background:#FF4154; } /* 빨강 */
+
+/* 모바일 */
+@media (max-width: 600px) {
+  .heroDesc { font-size: 16px; line-height: 24px; }
+  .badgeTitle { font-size: 20px; }
+  .badgeDesc { font-size: 16px; }
+  .card { padding: 24px; }
+}

--- a/src/pages/MyPage/BasicInfoPage.jsx
+++ b/src/pages/MyPage/BasicInfoPage.jsx
@@ -1,8 +1,10 @@
 // File: src/pages/MyPage/BasicInfoPage.jsx
 import React, { useState } from "react";
-import styles from "./BasicInfoPage.module.css"; // ✅ 같은 폴더의 모듈 CSS
+import styles from "./BasicInfoPage.module.css";
 import Button from "../../components/Common/Button";
 import PageLayout from "../../layouts/PageLayout";
+import SpecTab from "./SpecTab/SpecTab";
+import MyActivityTab from "./MyActivityTab/MyActivityTab";
 
 export default function BasicInfoPage() {
   const [activeTab, setActiveTab] = useState("기본정보");
@@ -27,14 +29,15 @@ export default function BasicInfoPage() {
     return { text, onClick: map[text] ?? (() => {}) };
   };
 
+  const tabs = ["기본정보", "스펙관리", "내 활동", "비밀번호 변경·탈퇴"];
+
   return (
     <PageLayout showHero={false}>
-      {/* 마이페이지 전용 컨테이너(헤더-컨텐츠 간격 포함) */}
       <div className={styles["mypage-container"]}>
         <div className={styles.bigbox}>
-          {/* 탭 */}
+          {/* 상단 탭 */}
           <div className={styles["basic-info__tabs"]}>
-            {["기본정보", "스펙관리", "비밀번호 변경", "회원 탈퇴"].map((tab) => (
+            {tabs.map((tab) => (
               <button
                 key={tab}
                 type="button"
@@ -53,9 +56,9 @@ export default function BasicInfoPage() {
             <h3 className={styles["basic-info__section-title"]}>{activeTab}</h3>
             <hr className={styles["basic-info__separator--main"]} />
 
+            {/* 기본정보 */}
             {activeTab === "기본정보" && (
               <>
-                {/* 아이디 */}
                 <div className={styles["basic-info__row"]}>
                   <label className={styles["basic-info__label"]}>아이디</label>
                   <span className={styles["basic-info__value"]}>
@@ -64,14 +67,12 @@ export default function BasicInfoPage() {
                 </div>
                 <hr className={styles["basic-info__separator"]} />
 
-                {/* 이름 */}
                 <div className={styles["basic-info__row"]}>
                   <label className={styles["basic-info__label"]}>이름</label>
                   <span className={styles["basic-info__value"]}>예인</span>
                 </div>
                 <hr className={styles["basic-info__separator"]} />
 
-                {/* 닉네임 */}
                 <div className={styles["basic-info__row--group"]}>
                   <label className={styles["basic-info__label"]}>닉네임</label>
                   <div className={styles["basic-info__field"]}>
@@ -92,7 +93,6 @@ export default function BasicInfoPage() {
                 </div>
                 <hr className={styles["basic-info__separator"]} />
 
-                {/* 이메일 */}
                 <div className={styles["basic-info__row--group"]}>
                   <label className={styles["basic-info__label"]}>이메일</label>
                   <div className={styles["basic-info__field"]}>
@@ -113,7 +113,6 @@ export default function BasicInfoPage() {
                 </div>
                 <hr className={styles["basic-info__separator"]} />
 
-                {/* 휴대폰 번호 */}
                 <div className={styles["basic-info__row--group"]}>
                   <label className={styles["basic-info__label"]}>휴대폰 번호</label>
                   <div className={styles["basic-info__field"]}>
@@ -134,11 +133,8 @@ export default function BasicInfoPage() {
                 </div>
                 <hr className={styles["basic-info__separator"]} />
 
-                {/* 관심 분야 / 직무 */}
                 <div className={styles["basic-info__row--group"]}>
-                  <label className={styles["basic-info__label"]}>
-                    관심 분야 / 직무
-                  </label>
+                  <label className={styles["basic-info__label"]}>관심 분야 / 직무</label>
                   <div
                     className={`${styles["basic-info__field"]} ${styles["basic-info__field--inline"]}`}
                   >
@@ -152,6 +148,19 @@ export default function BasicInfoPage() {
                   </div>
                 </div>
               </>
+            )}
+
+            {/* 스펙관리 */}
+            {activeTab === "스펙관리" && <SpecTab />}
+
+            {/* 내 활동: 자기소개서/스크랩 채용/면접 기록 */}
+            {activeTab === "내 활동" && <MyActivityTab />}
+
+            {/* 플레이스홀더 */}
+            {activeTab === "비밀번호 변경·탈퇴" && (
+              <div style={{ padding: "12px 0", color: "#777" }}>
+                비밀번호 변경 및 회원 탈퇴 화면 준비 중
+              </div>
             )}
           </div>
         </div>

--- a/src/pages/MyPage/MyActivityTab/InterviewHistory.jsx
+++ b/src/pages/MyPage/MyActivityTab/InterviewHistory.jsx
@@ -1,0 +1,67 @@
+// File: src/pages/MyPage/MyActivityTab/InterviewHistory.jsx
+import React, { useEffect, useState } from "react";
+import styles from "./MyActivityTab.module.css";
+import Button from "../../../components/Common/Button";
+
+export default function InterviewHistory() {
+  const userId = "user_abc";
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/interviews?userId=${encodeURIComponent(userId)}`);
+        if (!res.ok) throw new Error("면접 이력 조회 실패");
+        const data = await res.json();
+        if (!ignore) setItems(data || []);
+      } catch (e) {
+        setErr("면접 이력을 불러오는 데 실패했습니다. 다시 시도해주세요.");
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+    return () => { ignore = true; };
+  }, []);
+
+  const openReport = async (interviewId) => {
+    // 상세 리포트 페이지 이동 or 모달
+    // ex) navigate(`/interview/report/${interviewId}`)
+    alert(`리포트 보기: ${interviewId}`);
+  };
+
+  if (loading) return <div className={styles.loading}>불러오는 중…</div>;
+  if (err) return <div className={styles.error}>{err} <button onClick={()=>window.location.reload()}>재시도</button></div>;
+
+  if (!items.length) {
+    return (
+      <div className={styles.empty}>
+        아직 진행한 면접 연습 기록이 없습니다.
+        <div className={styles.muted}>AI 면접에서 연습을 시작해보세요.</div>
+      </div>
+    );
+  }
+
+  return (
+    <ul className={styles.cardList}>
+      {items.map(s => (
+        <li key={s.interviewId} className={styles.card}>
+          <div className={styles.cardHead}>
+            <h4 className={styles.cardTitle}>{s.date}</h4>
+            <span className={styles.muted}>질문 {s.questionCount}개 · {s.usedResumeVersion || "자소서 미지정"}</span>
+          </div>
+          <div className={styles.cardMeta}>
+            <span>총점 {typeof s.overallScore === "number" ? s.overallScore.toFixed(1) : "-"}</span>
+            {s.status && <span>상태 {s.status}</span>}
+          </div>
+          <div className={styles.cardActions}>
+            <Button text="리포트 보기" onClick={()=>openReport(s.interviewId)} />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/MyPage/MyActivityTab/MyActivityTab.jsx
+++ b/src/pages/MyPage/MyActivityTab/MyActivityTab.jsx
@@ -1,0 +1,39 @@
+// File: src/pages/MyPage/MyActivityTab/MyActivityTab.jsx
+import React, { useEffect, useState } from "react";
+import styles from "./MyActivityTab.module.css";
+import ResumeList from "./ResumeList";
+import SavedJobsList from "./SavedJobsList";
+import InterviewHistory from "./InterviewHistory";
+
+const SUB_TABS = ["자기소개서", "스크랩 채용", "면접 기록"];
+
+export default function MyActivityTab() {
+  const [active, setActive] = useState(SUB_TABS[0]);
+
+  // URL 쿼리로 탭 유지하고 싶다면 여기에 동기화 로직 추가 가능
+  useEffect(() => {
+    // noop
+  }, []);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.subtabs}>
+        {SUB_TABS.map((t) => (
+          <button
+            key={t}
+            className={`${styles.subtab} ${active === t ? styles.active : ""}`}
+            onClick={() => setActive(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.panel}>
+        {active === "자기소개서" && <ResumeList />}
+        {active === "스크랩 채용" && <SavedJobsList />}
+        {active === "면접 기록" && <InterviewHistory />}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyPage/MyActivityTab/MyActivityTab.module.css
+++ b/src/pages/MyPage/MyActivityTab/MyActivityTab.module.css
@@ -1,0 +1,39 @@
+/* File: src/pages/MyPage/MyActivityTab/MyActivityTab.module.css */
+.wrapper { display: grid; gap: 12px; }
+
+.subtabs { display: flex; gap: 8px; }
+.subtab {
+  flex: 0 0 auto; min-height: 36px; padding: 8px 12px;
+  border:1px solid #e9e9ea; border-radius: 999px; background:#fbfbfb; cursor:pointer;
+  font-weight:600;
+}
+.active { background:#3b375a; color:#fff; border-color:#3b375a; }
+
+.panel { border:1px solid #e9e9ea; border-radius: 12px; padding: 16px; background:#fff; }
+
+.loading { color:#666; padding: 8px 0; }
+.error { color:#d62f2f; padding: 8px 0; }
+.empty { color:#444; padding: 16px 0; display:flex; flex-direction:column; gap: 12px; }
+
+.listWrap { display: grid; gap: 12px; }
+.toolbar { display:flex; justify-content:space-between; align-items:center; gap: 12px; }
+.select { min-height: 36px; border:1px solid #e9e9ea; border-radius:8px; padding: 6px 10px; }
+
+.cardList { list-style:none; padding:0; margin:0; display:grid; gap:12px; }
+.card {
+  border:1px solid #e9e9ea; border-radius:12px; padding:12px; background:#fff;
+  display:grid; gap:10px;
+}
+.cardHead { display:flex; justify-content:space-between; align-items:center; gap: 12px; }
+.cardTitle { font-size:16px; font-weight:700; margin:0; }
+.cardMeta { display:flex; gap:12px; color:#555; }
+.cardActions { display:flex; gap: 8px; }
+.muted { color:#777; font-size:13px; }
+
+.tags { display:flex; flex-wrap:wrap; gap:6px; }
+.tag { border:1px solid #e9e9ea; border-radius:999px; padding:4px 8px; background:#fbfbfb; font-size:12px; }
+
+@media (max-width: 860px) {
+  .cardHead { flex-direction: column; align-items:flex-start; }
+  .toolbar { flex-direction: column; align-items: stretch; }
+}

--- a/src/pages/MyPage/MyActivityTab/ResumeList.jsx
+++ b/src/pages/MyPage/MyActivityTab/ResumeList.jsx
@@ -1,0 +1,91 @@
+// File: src/pages/MyPage/MyActivityTab/ResumeList.jsx
+import React, { useEffect, useState } from "react";
+import styles from "./MyActivityTab.module.css";
+import Button from "../../../components/Common/Button";
+
+export default function ResumeList() {
+  const userId = "user_abc"; // TODO: 실제 로그인 사용자로 대체
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+  const [items, setItems] = useState([]);
+  const [sort, setSort] = useState("최신순");
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/resumes?userId=${encodeURIComponent(userId)}`);
+        if (!res.ok) throw new Error("자기소개서 목록 조회 실패");
+        const data = await res.json();
+        if (!ignore) setItems(data || []);
+      } catch (e) {
+        setErr("데이터를 불러오지 못했습니다. 다시 시도해주세요.");
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+    return () => { ignore = true; };
+  }, []);
+
+  const sorted = [...items].sort((a, b) => {
+    if (sort === "최신순") return new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt);
+    if (sort === "제목순") return (a.title || "").localeCompare(b.title || "");
+    return 0;
+  });
+
+  const onOpen = (id) => {
+    // 상세 보기 or 편집 화면으로 이동
+    // ex) navigate(`/selfintro/${id}`)
+    alert(`자기소개서 열기: ${id}`);
+  };
+
+  const onCreate = () => {
+    // 새 작성하기 화면 이동
+    alert("새 자기소개서 작성");
+  };
+
+  if (loading) return <div className={styles.loading}>불러오는 중…</div>;
+  if (err) return <div className={styles.error}>{err} <button onClick={()=>window.location.reload()}>재시도</button></div>;
+
+  if (!sorted.length) {
+    return (
+      <div className={styles.empty}>
+        저장된 자기소개서가 없습니다.
+        <div>
+          <Button text="+ 새 자기소개서 작성" onClick={onCreate} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.listWrap}>
+      <div className={styles.toolbar}>
+        <Button text="+ 새 자기소개서 작성" onClick={onCreate} />
+        <select className={styles.select} value={sort} onChange={(e)=>setSort(e.target.value)}>
+          <option>최신순</option>
+          <option>제목순</option>
+        </select>
+      </div>
+
+      <ul className={styles.cardList}>
+        {sorted.map(item => (
+          <li key={item.resumeId} className={styles.card}>
+            <div className={styles.cardHead}>
+              <h4 className={styles.cardTitle}>{item.title}</h4>
+              <span className={styles.muted}>글자 수 {item.length?.toLocaleString() ?? 0}</span>
+            </div>
+            <div className={styles.cardMeta}>
+              <span>생성 {item.createdAt}</span>
+              <span>수정 {item.updatedAt || "-"}</span>
+            </div>
+            <div className={styles.cardActions}>
+              <Button text="열람/편집" onClick={()=>onOpen(item.resumeId)} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/MyPage/MyActivityTab/SavedJobsList.jsx
+++ b/src/pages/MyPage/MyActivityTab/SavedJobsList.jsx
@@ -1,0 +1,64 @@
+// File: src/pages/MyPage/MyActivityTab/SavedJobsList.jsx
+import React, { useEffect, useState } from "react";
+import styles from "./MyActivityTab.module.css";
+import Button from "../../../components/Common/Button";
+
+export default function SavedJobsList() {
+  const userId = "user_abc";
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/jobs/saved?userId=${encodeURIComponent(userId)}`);
+        if (!res.ok) throw new Error("스크랩 채용 목록 조회 실패");
+        const data = await res.json();
+        if (!ignore) setItems(data || []);
+      } catch (e) {
+        setErr("데이터를 불러오지 못했습니다. 다시 시도해주세요.");
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+    return () => { ignore = true; };
+  }, []);
+
+  const openJob = (jobId, url) => {
+    if (url) window.open(url, "_blank");
+    else alert(`채용 상세: ${jobId}`);
+  };
+
+  if (loading) return <div className={styles.loading}>불러오는 중…</div>;
+  if (err) return <div className={styles.error}>{err} <button onClick={()=>window.location.reload()}>재시도</button></div>;
+
+  if (!items.length) {
+    return <div className={styles.empty}>스크랩한 채용 공고가 없습니다.</div>;
+  }
+
+  return (
+    <ul className={styles.cardList}>
+      {items.map(job => (
+        <li key={job.jobId} className={styles.card}>
+          <div className={styles.cardHead}>
+            <h4 className={styles.cardTitle}>{job.title}</h4>
+            <span className={styles.muted}>{job.company}</span>
+          </div>
+          <div className={styles.cardMeta}>
+            <span>마감일 {job.deadline || "미정"}</span>
+            <span>등록 {job.savedAt || "-"}</span>
+          </div>
+          <div className={styles.tags}>
+            {job.tags?.map(t => <span key={t} className={styles.tag}>{t}</span>)}
+          </div>
+          <div className={styles.cardActions}>
+            <Button text="공고 보기" onClick={()=>openJob(job.jobId, job.url)} />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/MyPage/SpecTab/CertificateList.jsx
+++ b/src/pages/MyPage/SpecTab/CertificateList.jsx
@@ -1,0 +1,35 @@
+// File: src/pages/MyPage/SpecTab/CertificateList.jsx
+import React from "react";
+import styles from "./SpecTab.module.css";
+
+export default function CertificateList({ items, onChange }) {
+  const addRow = () => onChange([...items, { name: "", organization: "", issueDate: "" }]);
+  const remove = (idx) => onChange(items.filter((_, i) => i !== idx));
+  const set = (idx, key, val) => {
+    const next = items.map((it, i) => (i === idx ? { ...it, [key]: val } : it));
+    onChange(next);
+  };
+
+  return (
+    <div className={styles.listStack}>
+      {items.map((it, idx) => (
+        <div key={idx} className={styles.grid3}>
+          <div className={styles.field}>
+            <label>자격증명</label>
+            <input value={it.name} onChange={e => set(idx, "name", e.target.value)} placeholder="정보처리기사" />
+          </div>
+          <div className={styles.field}>
+            <label>발급 기관</label>
+            <input value={it.organization} onChange={e => set(idx, "organization", e.target.value)} placeholder="한국산업인력공단" />
+          </div>
+          <div className={styles.field}>
+            <label>발급일 (YYYY-MM-DD)</label>
+            <input value={it.issueDate} onChange={e => set(idx, "issueDate", e.target.value)} placeholder="2024-06-01" />
+          </div>
+          <button type="button" className={styles.removeBtn} onClick={() => remove(idx)}>삭제</button>
+        </div>
+      ))}
+      <button type="button" className={styles.addBtn} onClick={addRow}>+ 자격증 추가</button>
+    </div>
+  );
+}

--- a/src/pages/MyPage/SpecTab/EducationSection.jsx
+++ b/src/pages/MyPage/SpecTab/EducationSection.jsx
@@ -1,0 +1,38 @@
+// File: src/pages/MyPage/SpecTab/EducationSection.jsx
+import React from "react";
+import styles from "./SpecTab.module.css";
+
+export default function EducationSection({ value, onChange }) {
+  return (
+    <div className={styles.grid2}>
+      <div className={styles.field}>
+        <label>학교명 *</label>
+        <input value={value.school} onChange={e => onChange("school", e.target.value)} placeholder="숙명여자대학교" />
+      </div>
+      <div className={styles.field}>
+        <label>전공 *</label>
+        <input value={value.major} onChange={e => onChange("major", e.target.value)} placeholder="인공지능공학부" />
+      </div>
+
+      <div className={styles.field}>
+        <label>재학 상태 *</label>
+        <select value={value.status} onChange={e => onChange("status", e.target.value)}>
+          <option value="재학">재학</option>
+          <option value="휴학">휴학</option>
+          <option value="졸업예정">졸업예정</option>
+          <option value="졸업">졸업</option>
+        </select>
+      </div>
+
+      <div className={styles.field}>
+        <label>입학 연도 *</label>
+        <input value={value.admissionYear} onChange={e => onChange("admissionYear", e.target.value)} placeholder="2022" />
+      </div>
+
+      <div className={styles.field}>
+        <label>졸업 연도</label>
+        <input value={value.graduationYear} onChange={e => onChange("graduationYear", e.target.value)} placeholder="2026" />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyPage/SpecTab/ExperienceList.jsx
+++ b/src/pages/MyPage/SpecTab/ExperienceList.jsx
@@ -1,0 +1,39 @@
+// File: src/pages/MyPage/SpecTab/ExperienceList.jsx
+import React from "react";
+import styles from "./SpecTab.module.css";
+
+export default function ExperienceList({ items, onChange }) {
+  const addRow = () => onChange([...items, { company: "", role: "", period: "", description: "" }]);
+  const remove = (idx) => onChange(items.filter((_, i) => i !== idx));
+  const set = (idx, key, val) => {
+    const next = items.map((it, i) => (i === idx ? { ...it, [key]: val } : it));
+    onChange(next);
+  };
+
+  return (
+    <div className={styles.listStack}>
+      {items.map((it, idx) => (
+        <div key={idx} className={styles.grid2}>
+          <div className={styles.field}>
+            <label>회사명</label>
+            <input value={it.company} onChange={e => set(idx, "company", e.target.value)} placeholder="AI 스타트업" />
+          </div>
+          <div className={styles.field}>
+            <label>직무</label>
+            <input value={it.role} onChange={e => set(idx, "role", e.target.value)} placeholder="백엔드 인턴" />
+          </div>
+          <div className={styles.field}>
+            <label>재직 기간</label>
+            <input value={it.period} onChange={e => set(idx, "period", e.target.value)} placeholder="2023.07 ~ 2023.08" />
+          </div>
+          <div className={styles.fieldFull}>
+            <label>주요 업무</label>
+            <textarea rows={3} value={it.description} onChange={e => set(idx, "description", e.target.value)} placeholder="Spring 기반 API 개발 및 테스트" />
+          </div>
+          <button type="button" className={styles.removeBtn} onClick={() => remove(idx)}>삭제</button>
+        </div>
+      ))}
+      <button type="button" className={styles.addBtn} onClick={addRow}>+ 경력 추가</button>
+    </div>
+  );
+}

--- a/src/pages/MyPage/SpecTab/SkillsInput.jsx
+++ b/src/pages/MyPage/SpecTab/SkillsInput.jsx
@@ -1,0 +1,47 @@
+// File: src/pages/MyPage/SpecTab/SkillsInput.jsx
+import React, { useRef, useState } from "react";
+import styles from "./SpecTab.module.css";
+
+export default function SkillsInput({ value = [], onChange, placeholder }) {
+  const [input, setInput] = useState("");
+  const ref = useRef(null);
+
+  const add = (txt) => {
+    const clean = txt.trim();
+    if (!clean) return;
+    if (value.includes(clean)) return;
+    onChange([...value, clean]);
+    setInput("");
+    ref.current?.focus();
+  };
+
+  const remove = (skill) => onChange(value.filter(s => s !== skill));
+
+  const onKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      add(input);
+    }
+  };
+
+  return (
+    <div>
+      <div className={styles.chipsWrap}>
+        {value.map((s) => (
+          <span key={s} className={styles.chip} onClick={() => remove(s)}>
+            {s} ✕
+          </span>
+        ))}
+        <input
+          ref={ref}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          className={styles.chipsInput}
+        />
+      </div>
+      <p className={styles.helper}>엔터 또는 쉼표로 스킬을 추가하세요.</p>
+    </div>
+  );
+}

--- a/src/pages/MyPage/SpecTab/SpecTab.jsx
+++ b/src/pages/MyPage/SpecTab/SpecTab.jsx
@@ -1,0 +1,193 @@
+// File: src/pages/MyPage/SpecTab/SpecTab.jsx
+import React, { useEffect, useMemo, useState } from "react";
+import styles from "./SpecTab.module.css";
+import Button from "../../../components/Common/Button";
+
+import EducationSection from "./EducationSection";
+import CertificateList from "./CertificateList";
+import ExperienceList from "./ExperienceList";
+import SkillsInput from "./SkillsInput";
+
+export default function SpecTab() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const [form, setForm] = useState({
+    education: { school: "", major: "", status: "재학", admissionYear: "", graduationYear: "" },
+    certificates: [{ name: "", organization: "", issueDate: "" }],
+    experience: [{ company: "", role: "", period: "", description: "" }],
+    skills: [], // ["Python","Figma"]
+  });
+
+  // TODO: 실제 로그인 사용자의 ID로 대체
+  const userId = "user_abc";
+
+  // 최초 로딩 (기존 데이터 조회)
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/profile?userId=${encodeURIComponent(userId)}`);
+        if (!res.ok) throw new Error("조회 실패");
+        const data = await res.json();
+        if (ignore) return;
+        setForm({
+          education: data.education ?? form.education,
+          certificates: data.certificates?.length ? data.certificates : form.certificates,
+          experience: data.experience?.length ? data.experience : form.experience,
+          skills: data.skills ?? [],
+        });
+      } catch (e) {
+        // 데이터가 없어도 신규 입력이면 그냥 무시
+        console.warn(e);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+    return () => { ignore = true; };
+  }, []); // eslint-disable-line
+
+  const setField = (path, value) => {
+    setForm(prev => {
+      const next = structuredClone(prev);
+      // 간단 path setter
+      const keys = path.split(".");
+      let cur = next;
+      for (let i = 0; i < keys.length - 1; i++) cur = cur[keys[i]];
+      cur[keys.at(-1)] = value;
+      return next;
+    });
+  };
+
+  // 필수값 검사
+  const validate = () => {
+    const { school, major, status, admissionYear } = form.education;
+    if (!school?.trim()) return "학력의 학교명을 입력해주세요.";
+    if (!major?.trim()) return "학력의 전공을 입력해주세요.";
+    if (!status) return "학력의 재학/졸업 상태를 선택해주세요.";
+    if (!/^\d{4}$/.test(String(admissionYear))) return "입학연도는 YYYY 형식으로 입력해주세요.";
+    if (form.education.graduationYear && !/^\d{4}$/.test(String(form.education.graduationYear))) {
+      return "졸업연도는 YYYY 형식으로 입력해주세요.";
+    }
+    // 자격증 날짜 형식
+    for (const c of form.certificates) {
+      if (!c.name && !c.organization && !c.issueDate) continue; // 빈줄 허용
+      if (!c.name?.trim()) return "자격증명을 입력해주세요.";
+      if (!c.organization?.trim()) return "발급 기관을 입력해주세요.";
+      if (c.issueDate && !/^\d{4}-\d{2}-\d{2}$/.test(c.issueDate)) return "자격증 발급일은 YYYY-MM-DD 형식입니다.";
+    }
+    // 경력
+    for (const e of form.experience) {
+      if (!e.company && !e.role && !e.period && !e.description) continue;
+      if (!e.company?.trim()) return "경력의 회사명을 입력해주세요.";
+      if (!e.role?.trim()) return "경력의 직무를 입력해주세요.";
+    }
+    return "";
+  };
+
+  const onSave = async () => {
+    setError("");
+    const err = validate();
+    if (err) {
+      setError(err);
+      window.alert("모든 필수 항목을 확인해주세요."); // 토스트 대체
+      return;
+    }
+    try {
+      setSaving(true);
+      const payload = {
+        userId,
+        education: {
+          ...form.education,
+          admissionYear: Number(form.education.admissionYear) || "",
+          graduationYear: form.education.graduationYear ? Number(form.education.graduationYear) : "",
+        },
+        certificates: form.certificates.filter(c => c.name || c.organization || c.issueDate),
+        experience: form.experience.filter(e => e.company || e.role || e.period || e.description),
+        skills: form.skills,
+      };
+      const res = await fetch("/api/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("저장 실패");
+      window.alert("이력 정보가 저장되었습니다");
+    } catch (e) {
+      console.error(e);
+      window.alert("이력 정보 저장에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const summary = useMemo(() => {
+    const school = form.education.school || "-";
+    const major = form.education.major || "-";
+    const certCount = (form.certificates || []).filter(c => c.name).length;
+    const expCount = (form.experience || []).filter(e => e.company).length;
+    return { school, major, certCount, expCount, skills: form.skills };
+  }, [form]);
+
+  if (loading) return <div className={styles.skeleton}>불러오는 중...</div>;
+
+  return (
+    <div className={styles.wrapper}>
+      {/* 상단 요약 카드 */}
+      <section className={styles.summaryCard}>
+        <div>
+          <div className={styles.summaryTitle}>{summary.school}</div>
+          <div className={styles.summarySub}>{summary.major}</div>
+        </div>
+        <div className={styles.summaryMeta}>
+          <span>자격증 {summary.certCount}개</span>
+          <span>경력 {summary.expCount}건</span>
+          {!!summary.skills?.length && <span>스킬 {summary.skills.length}개</span>}
+        </div>
+      </section>
+
+      {/* 입력 폼 */}
+      <section className={styles.formSection}>
+        <details open className={styles.accordion}>
+          <summary>학력</summary>
+          <EducationSection value={form.education} onChange={(k, v) => setField(`education.${k}`, v)} />
+        </details>
+
+        <details className={styles.accordion}>
+          <summary>자격증</summary>
+          <CertificateList
+            items={form.certificates}
+            onChange={(items) => setField("certificates", items)}
+          />
+        </details>
+
+        <details className={styles.accordion}>
+          <summary>경력</summary>
+          <ExperienceList
+            items={form.experience}
+            onChange={(items) => setField("experience", items)}
+          />
+        </details>
+
+        <details className={styles.accordion}>
+          <summary>기술 스택 (선택)</summary>
+          <SkillsInput
+            value={form.skills}
+            onChange={(skills) => setField("skills", skills)}
+            placeholder="예: Python, Figma, React"
+          />
+        </details>
+
+        {error && <p className={styles.errorText}>{error}</p>}
+      </section>
+
+      {/* 하단 고정 저장 바 */}
+      <div className={styles.saveBar}>
+        <div className={styles.saveBar__hint}>필수 항목을 입력한 뒤 저장하세요.</div>
+        <Button text={saving ? "저장 중..." : "저장"} onClick={onSave} disabled={saving} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyPage/SpecTab/SpecTab.module.css
+++ b/src/pages/MyPage/SpecTab/SpecTab.module.css
@@ -1,0 +1,62 @@
+.wrapper { position: relative; padding-bottom: 96px; } /* 저장바 공간 */
+.skeleton { padding: 24px; color: #777; }
+
+.summaryCard {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 20px; border: 1px solid #e9e9ea; border-radius: 12px; background:#fbfbfb;
+  margin-bottom: 16px;
+}
+.summaryTitle { font-size: 18px; font-weight: 700; }
+.summarySub { color:#666; margin-top: 2px; }
+.summaryMeta { display: flex; gap: 12px; color:#444; }
+
+.formSection { margin-top: 12px; display: grid; gap: 12px; }
+
+.accordion {
+  border: 1px solid #e9e9ea; border-radius: 10px; background: #fff; padding: 8px 12px;
+}
+.accordion > summary { cursor: pointer; font-weight: 600; padding: 8px 4px; }
+
+.grid2 { display: grid; gap: 12px; grid-template-columns: 1fr 1fr; }
+.grid3 { display: grid; gap: 12px; grid-template-columns: 1fr 1fr 1fr; }
+.field, .fieldFull { display: flex; flex-direction: column; gap: 6px; }
+.fieldFull { grid-column: 1 / -1; }
+.field label { font-size: 13px; color:#444; }
+.field input, .field select, .field textarea {
+  border: 1px solid #e9e9ea; border-radius: 8px; min-height: 38px; padding: 8px 10px; font-size: 14px;
+}
+.field textarea { resize: vertical; }
+
+.listStack { display: grid; gap: 12px; }
+.addBtn, .removeBtn {
+  border: 1px dashed #c9c9cb; background: #fff; border-radius: 8px; padding: 8px 10px; cursor: pointer;
+}
+.removeBtn { justify-self: start; }
+
+.errorText { color: #d62f2f; font-size: 13px; margin-top: 8px; }
+
+.saveBar {
+  position: fixed; left: 50%; transform: translateX(-50%); bottom: 24px;
+  width: min(100%, 980px); background: #ffffff; border: 1px solid #e9e9ea;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.08); border-radius: 12px;
+  padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; gap: 12px;
+}
+.saveBar__hint { color:#666; font-size: 14px; }
+
+.chipsWrap {
+  display: flex; flex-wrap: wrap; gap: 8px; border:1px solid #e9e9ea; border-radius: 8px; padding: 8px;
+}
+.chip {
+  padding: 6px 10px; border-radius: 999px; border: 1px solid #e9e9ea; background:#fbfbfb;
+  font-size: 13px; cursor: pointer;
+}
+.chipsInput {
+  min-width: 180px; border: none; outline: none; font-size: 14px;
+}
+.helper { font-size: 12px; color:#777; margin-top: 4px; }
+
+/* 반응형 */
+@media (max-width: 860px) {
+  .grid2, .grid3 { grid-template-columns: 1fr; }
+  .saveBar { width: calc(100% - 24px); left: 12px; right: 12px; transform: none; }
+}


### PR DESCRIPTION
## 작업 내용
- 마이페이지 상단 탭 구조 변경 (기본정보 / 스펙관리 / 내 활동 / 비밀번호 변경·탈퇴)
- SpecTab 컴포넌트 연동 (학력/자격증/경력/스킬 입력 및 저장 UI)
- MyActivityTab 구현 및 서브탭 추가
  - 자기소개서: 목록 조회, 정렬, 빈 상태, 새 작성 버튼
  - 스크랩 채용: 목록 조회, 태그 표시, 외부 링크 열기
  - 면접 기록: 목록 조회, 총점 표시, 리포트 보기 버튼
- CSS Module 스타일 작성
- 불필요 파일(MyPageTabs.jsx) 삭제

## 변경 사항
- `src/pages/MyPage/BasicInfoPage.jsx` 탭 구조 수정
- `src/pages/MyPage/SpecTab/*` 신규 추가
- `src/pages/MyPage/MyActivityTab/*` 신규 추가
- `src/pages/MyPage/MyPageTabs.jsx` 삭제
- 스타일 파일 추가

## 테스트
- 로컬 환경에서 탭 전환, 데이터 로딩, 빈 상태, 에러 상태 확인
- 버튼 클릭 시 알림 동작 정상 여부 확인

## 관련 이슈
Closes #10 

<img width="1254" height="733" alt="스크린샷 2025-08-12 오후 2 03 40" src="https://github.com/user-attachments/assets/18bda287-c142-42f0-8229-74244400020a" />

