### PR TITLE
[feat] Selfintro : 보드형 자기소개서 페이지 + 라우트 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import BasicInfoPage from './pages/MyPage/BasicInfoPage';
 import CategorySelect from "./pages/Interview/CategorySelect";
 import InterviewPrep from './pages/InterviewPrep/InterviewPrepPage';
 import InterviewSessionPage from './pages/Interview/InterviewSessionPage';
+import SelfIntroPage from './pages/SelfIntro/SelfIntroPage';
 import "./App.css";
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
           <Route path="/ai-interview" element={<CategorySelect />} />
           <Route path="/interview-prep" element={<InterviewPrep />} />
           <Route path="/interview/session" element={<InterviewSessionPage />} />
+          <Route path="/selfintro" element={<SelfIntroPage />} />
         </Routes>
       </main>
     </Router>

--- a/src/pages/SelfIntro/SelfIntroPage.jsx
+++ b/src/pages/SelfIntro/SelfIntroPage.jsx
@@ -1,0 +1,326 @@
+import React, { useEffect, useMemo, useState } from "react";
+import PageHero from "../../components/Common/PageHero";
+import Button from "../../components/Common/Button";
+import styles from "./SelfIntroPage.module.css";
+
+const STAGES = [
+  { id: "draft", label: "작성 중" },
+  { id: "screening", label: "서류 전형" },
+  { id: "round1", label: "1차 전형" },
+  { id: "round2", label: "2차 전형" },
+  { id: "final", label: "최종 전형" },
+];
+
+const SORT_OPTIONS = [
+  { id: "latest", label: "최신 순으로 정렬" },
+  { id: "oldest", label: "오래된 순으로 정렬" },
+  { id: "title", label: "제목순 정렬" },
+];
+
+const PERIOD_OPTIONS = [
+  { id: "all", label: "전체 기간" },
+  { id: "7", label: "최근 7일" },
+  { id: "30", label: "최근 30일" },
+  { id: "90", label: "최근 90일" },
+];
+
+const STORAGE_KEY = "selfintro:board:v1";
+
+function nowISO() {
+  return new Date().toISOString();
+}
+
+export default function SelfIntroPage() {
+  // --------- 상태
+  const [items, setItems] = useState([]);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState(SORT_OPTIONS[0].id);
+  const [period, setPeriod] = useState(PERIOD_OPTIONS[0].id);
+
+  // 편집 모달
+  const [editing, setEditing] = useState(null); // item 또는 null
+
+  // --------- 로컬스토리지
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) setItems(JSON.parse(raw));
+      else {
+        // 첫 진입용 샘플
+        setItems([
+          {
+            id: crypto.randomUUID(),
+            title: "새 자기소개서",
+            company: "",
+            stage: "draft",
+            updatedAt: nowISO(),
+            body: "",
+          },
+        ]);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
+
+  // --------- 필터링/정렬
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    let arr = items.filter((it) => {
+      const inSearch =
+        !term ||
+        it.title.toLowerCase().includes(term) ||
+        (it.company || "").toLowerCase().includes(term) ||
+        (it.body || "").toLowerCase().includes(term);
+
+      if (!inSearch) return false;
+
+      if (period === "all") return true;
+      const days = Number(period);
+      const from = Date.now() - days * 24 * 60 * 60 * 1000;
+      return new Date(it.updatedAt).getTime() >= from;
+    });
+
+    switch (sort) {
+      case "oldest":
+        arr = arr.sort(
+          (a, b) => new Date(a.updatedAt) - new Date(b.updatedAt)
+        );
+        break;
+      case "title":
+        arr = arr.sort((a, b) => a.title.localeCompare(b.title));
+        break;
+      case "latest":
+      default:
+        arr = arr.sort(
+          (a, b) => new Date(b.updatedAt) - new Date(a.updatedAt)
+        );
+    }
+    return arr;
+  }, [items, search, sort, period]);
+
+  const byStage = useMemo(() => {
+    const map = Object.fromEntries(STAGES.map((s) => [s.id, []]));
+    filtered.forEach((it) => {
+      if (!map[it.stage]) map[it.stage] = [];
+      map[it.stage].push(it);
+    });
+    return map;
+  }, [filtered]);
+
+  // --------- 액션
+  const handleCreate = (stageId) => {
+    const newItem = {
+      id: crypto.randomUUID(),
+      title: "새 자기소개서",
+      company: "",
+      stage: stageId,
+      updatedAt: nowISO(),
+      body: "",
+    };
+    setItems((prev) => [newItem, ...prev]);
+    setEditing(newItem);
+  };
+
+  const handleEditOpen = (item) => setEditing(item);
+  const handleDelete = (id) => {
+    if (!window.confirm("삭제하시겠어요?")) return;
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    setEditing(null);
+  };
+
+  const handleMove = (id, nextStage) => {
+    setItems((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, stage: nextStage, updatedAt: nowISO() } : i))
+    );
+  };
+
+  const handleSaveModal = (payload) => {
+    setItems((prev) =>
+      prev.map((i) => (i.id === payload.id ? { ...i, ...payload, updatedAt: nowISO() } : i))
+    );
+    setEditing(null);
+  };
+
+  return (
+    <div className={styles.page}>
+      <PageHero
+        badge="자기소개서"
+        title="자기소개서 작성"
+        subtitle="지원 중인 공고 별로 자소서를 정리하고 단계별로 관리해 보세요."
+        maxWidth={1200}
+      />
+
+      {/* 필터 바 */}
+      <div className={styles.toolbar}>
+        <div className={styles.selects}>
+          <div className={styles.select}>
+            <select value={period} onChange={(e) => setPeriod(e.target.value)}>
+              {PERIOD_OPTIONS.map((o) => (
+                <option key={o.id} value={o.id}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.select}>
+            <select value={sort} onChange={(e) => setSort(e.target.value)}>
+              {SORT_OPTIONS.map((o) => (
+                <option key={o.id} value={o.id}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className={styles.search}>
+          <span className={styles.searchIcon} aria-hidden>🔍</span>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="기업명, 자기소개서 제목, 내용 검색"
+          />
+        </div>
+      </div>
+
+      {/* 보드 */}
+      <div className={styles.board}>
+        {STAGES.map((stage) => (
+          <div key={stage.id} className={styles.column}>
+            <div className={styles.colHeader}>
+              <div className={styles.colTitle}>{stage.label}</div>
+              <div className={styles.counter}>
+                {byStage[stage.id]?.length || 0}
+              </div>
+            </div>
+
+            <button
+              className={styles.addCard}
+              onClick={() => handleCreate(stage.id)}
+            >
+              + 새 자소서 작성
+            </button>
+
+            <div className={styles.cardList}>
+              {byStage[stage.id]?.map((card) => (
+                <article key={card.id} className={styles.card}>
+                  <div className={styles.cardHead}>
+                    <h4 className={styles.cardTitle}>
+                      {card.title || "제목 없음"}
+                    </h4>
+                    <button
+                      className={styles.cardMenu}
+                      title="편집"
+                      onClick={() => handleEditOpen(card)}
+                    >
+                      ⋯
+                    </button>
+                  </div>
+                  {card.company && (
+                    <div className={styles.cardMeta}>{card.company}</div>
+                  )}
+                  <div className={styles.cardDate}>
+                    {new Date(card.updatedAt).toLocaleDateString()}
+                  </div>
+
+                  {/* 빠른 이동 버튼 */}
+                  <div className={styles.quickMoves}>
+                    {STAGES.filter((s) => s.id !== card.stage).map((s) => (
+                      <button
+                        key={s.id}
+                        className={styles.quickBtn}
+                        onClick={() => handleMove(card.id, s.id)}
+                      >
+                        {s.label}
+                      </button>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {editing && (
+        <EditModal
+          data={editing}
+          onClose={() => setEditing(null)}
+          onSave={handleSaveModal}
+          onDelete={() => handleDelete(editing.id)}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ----------------- 모달 컴포넌트 ----------------- */
+function EditModal({ data, onClose, onSave, onDelete }) {
+  const [title, setTitle] = useState(data.title || "");
+  const [company, setCompany] = useState(data.company || "");
+  const [stage, setStage] = useState(data.stage);
+  const [body, setBody] = useState(data.body || "");
+
+  return (
+    <div className={styles.modalBackdrop} role="dialog" aria-modal="true">
+      <div className={styles.modal}>
+        <header className={styles.modalHeader}>
+          <h3>자기소개서 편집</h3>
+        </header>
+
+        <div className={styles.modalBody}>
+          <label className={styles.field}>
+            <span>제목</span>
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="예) 2025 상반기 ○○기업 지원서"
+            />
+          </label>
+
+          <label className={styles.field}>
+            <span>기업명</span>
+            <input
+              value={company}
+              onChange={(e) => setCompany(e.target.value)}
+              placeholder="회사명을 입력하세요"
+            />
+          </label>
+
+          <label className={styles.field}>
+            <span>단계</span>
+            <select value={stage} onChange={(e) => setStage(e.target.value)}>
+              {STAGES.map((s) => (
+                <option key={s.id} value={s.id}>{s.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className={styles.field}>
+            <span>내용</span>
+            <textarea
+              rows={9}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="자기소개서 내용을 입력하세요"
+            />
+          </label>
+        </div>
+
+        <footer className={styles.modalFooter}>
+          <Button className={styles.deleteBtn} onClick={onDelete}>삭제</Button>
+          <div className={styles.modalActions}>
+            <Button className={styles.secondaryBtn} onClick={onClose}>닫기</Button>
+            <Button
+              className={styles.primaryBtn}
+              onClick={() => onSave({ ...data, title, company, stage, body })}
+            >
+              저장
+            </Button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SelfIntro/SelfIntroPage.module.css
+++ b/src/pages/SelfIntro/SelfIntroPage.module.css
@@ -1,0 +1,115 @@
+.page { background:#ebf5fd; min-height:100vh; }
+
+/* 상단 툴바 */
+.toolbar {
+  max-width:1320px; margin:0 auto; padding:0 16px 22px;
+  display:flex; gap:14px; align-items:center; justify-content:space-between;
+}
+.selects { display:flex; gap:10px; }
+.select select {
+  appearance:none; -webkit-appearance:none;
+  background:#fff; border:1px solid #d7def0; border-radius:10px;
+  padding:10px 14px; font-size:14px; min-width:120px; color:#27314d;
+  box-shadow:0 4px 10px rgba(20,30,60,0.08);
+}
+.search {
+  display:flex; align-items:center; background:#fff; gap:8px;
+  border:1px solid #d7def0; border-radius:12px; padding:10px 12px;
+  width:100%; max-width:360px; box-shadow:0 4px 10px rgba(20,30,60,0.08);
+}
+.search input { border:0; outline:none; width:100%; font-size:14px; }
+.searchIcon { opacity:.6; }
+
+/* 보드 */
+.board {
+  max-width:1320px; margin:0 auto; padding:0 16px 60px;
+  display:grid; grid-template-columns: repeat(5, 1fr); gap:16px;
+}
+.column {
+  background:#ffffff; border:1px solid #e6ebf4; border-radius:16px;
+  box-shadow:0 8px 24px rgba(20,30,60,0.08); padding:12px;
+  display:flex; flex-direction:column; min-height:520px;
+}
+.colHeader {
+  background:#322d52; color:#fff; border-radius:12px; padding:10px 12px;
+  display:flex; align-items:center; justify-content:space-between;
+  box-shadow: inset 0 0 0 1px #47406d;
+}
+.colTitle { font-weight:800; letter-spacing:.2px; }
+.counter {
+  background:#ffffff; color:#322d52; font-weight:800;
+  width:28px; height:22px; display:flex; align-items:center; justify-content:center;
+  border-radius:999px; border:1px solid #cfd3ea;
+}
+
+.addCard {
+  margin:12px 0; width:100%; text-align:left;
+  background:#f3f5fb; border:1px dashed #c6cde6; color:#2f2a4f;
+  border-radius:10px; padding:10px 12px; cursor:pointer; font-weight:700;
+}
+.addCard:hover { background:#eef2fb; }
+
+.cardList { display:flex; flex-direction:column; gap:10px; overflow:auto; padding-bottom:6px; }
+.card {
+  background:#fff; border:1px solid #e6ebf4; border-radius:12px;
+  box-shadow:0 6px 16px rgba(20,30,60,0.06); padding:12px;
+}
+.cardHead { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.cardTitle { margin:0; font-size:14px; color:#1f2a44; font-weight:800; }
+.cardMenu { background:transparent; border:0; font-size:20px; cursor:pointer; line-height:1; color:#6b7391; }
+.cardMeta { margin-top:6px; color:#4a5678; font-size:13px; }
+.cardDate { margin-top:4px; color:#8a93ad; font-size:12px; }
+
+.quickMoves { display:flex; flex-wrap:wrap; gap:6px; margin-top:10px; }
+.quickBtn {
+  border:1px solid #cfd6ec; background:#fafbff; font-size:12px; padding:6px 8px;
+  border-radius:999px; cursor:pointer;
+}
+.quickBtn:hover { background:#f1f4ff; }
+
+/* 모달 */
+.modalBackdrop {
+  position:fixed; inset:0; background:rgba(10,14,30,.35);
+  display:flex; align-items:center; justify-content:center; z-index:1000;
+}
+.modal {
+  width:min(720px, 92vw); background:#fff; border-radius:20px;
+  box-shadow:0 16px 40px rgba(0,0,0,.2); overflow:hidden; border:1px solid #e6ebf4;
+}
+.modalHeader { padding:16px 18px; border-bottom:1px solid #eef1f7; }
+.modalHeader h3 { margin:0; font-size:18px; color:#1f2a44; }
+
+.modalBody { padding:16px 18px; display:grid; gap:12px; }
+.field { display:grid; gap:6px; }
+.field > span { font-size:13px; color:#3a4669; font-weight:700; }
+.field input, .field select, .field textarea {
+  border:1px solid #d7def0; border-radius:10px; padding:10px 12px; font-size:14px;
+  outline:none; background:#fff;
+}
+.field textarea { resize:vertical; }
+
+.modalFooter {
+  padding:14px 18px; border-top:1px solid #eef1f7; display:flex; justify-content:space-between; align-items:center;
+}
+.modalActions { display:flex; gap:10px; }
+.primaryBtn {
+  width:120px; height:40px; font-size:16px; font-weight:800;
+  background:#0f1b33; color:#fff !important; border:none; border-radius:12px;
+}
+.secondaryBtn {
+  width:120px; height:40px; font-size:16px; font-weight:800;
+  background:#ffffff; color:#0f1b33 !important; border:2px solid #a0acc7; border-radius:12px;
+}
+.deleteBtn {
+  background:#fff0f0; color:#b31919 !important; border:1px solid #f1c8c8;
+  border-radius:10px; height:40px; padding:0 14px; font-weight:800;
+}
+
+/* 반응형 */
+@media (max-width:1180px) {
+  .board { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width:760px) {
+  .toolbar { flex-direction:column; align-items:stretch; }
+  .board { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
### - 변경 요약
selfintro 페이지 진입 시 기본 레이아웃을 5열 보드 형태로 구성
새 자소서 작성 버튼 추가 및 클릭 시 모달 표시
검색, 정렬, 기간 필터 기능 구현
필터/검색 조건 로컬스토리지 저장 기능 추가

### - 테스트 방법
브라우저에서 selfintro 페이지 진입
화면에 5열 보드와 + 새 자소서 작성 버튼이 보이는지 확인
버튼 클릭 시 새 자소서 작성 모달이 정상적으로 표시되는지 확인
검색어 입력, 정렬 선택, 기간 필터 적용 시 보드 내용이 필터링되는지 확인
페이지 새로고침 후에도 이전 필터/검색 조건이 유지되는지(로컬스토리지 저장) 확인

### - 자기소개서 스크린샷
<img width="1884" height="870" alt="스크린샷 2025-08-14 122451" src="https://github.com/user-attachments/assets/08ddc52a-bf12-4f0f-9f62-d917667d069a" />
