### PR TITLE
Feat: 얼굴 마스크 및 눈·코·입 가이드라인 추가

### DIFF
--- a/src/pages/Interview/InterviewSessionPage.jsx
+++ b/src/pages/Interview/InterviewSessionPage.jsx
@@ -9,7 +9,6 @@ export default function InterviewSessionPage() {
   const { state } = useLocation();
   // const navigate = useNavigate();
 
-  // 질문/직무: Precheck → navigate(... { state }) 경로가 없을 때도 동작하도록 기본값 제공
   const questions =
     Array.isArray(state?.questions) && state.questions.length > 0
       ? state.questions
@@ -18,9 +17,13 @@ export default function InterviewSessionPage() {
           "최근에 해결한 기술적 문제와 접근 방법을 설명해 주세요.",
           "협업 과정에서 갈등을 해결한 경험을 말해 주세요.",
         ];
-
   const job =
     state?.job || "경영·인사·총무·사무/인사·인재개발·채용·교육·HR";
+
+  // ===== 인트로(5초 안내) → 질문 단계 전환 =====
+  const [phase, setPhase] = useState("intro"); // 'intro' | 'question'
+  const INTRO_SECONDS = 5;
+  const [introLeft, setIntroLeft] = useState(INTRO_SECONDS);
 
   // 진행 중 질문 인덱스
   const [index, setIndex] = useState(0);
@@ -29,7 +32,7 @@ export default function InterviewSessionPage() {
   // 타이머
   const ANSWER_SECONDS = 60;
   const [secondsLeft, setSecondsLeft] = useState(ANSWER_SECONDS);
-  const [isRunning, setIsRunning] = useState(true);
+  const [isRunning, setIsRunning] = useState(false); // 인트로 동안은 false
   const timerRef = useRef(null);
 
   // 원형 진행바 계산
@@ -45,6 +48,24 @@ export default function InterviewSessionPage() {
   const videoRef = useRef(null);
   const streamRef = useRef(null);
 
+  // ===== 카메라/얼굴 상태 =====
+  const [camReady, setCamReady] = useState(false);
+  const [camError, setCamError] = useState(false);
+  const [faceReady, setFaceReady] = useState(false);
+  const introStartedRef = useRef(false); // 카운트다운 중복 시작 방지
+
+  // ===== 베이스라인(시선 라벨) 수집 =====
+  const baselineRef = useRef(null);
+  const gazeSamplesRef = useRef([]);
+  const sampleTimerRef = useRef(null);
+  const introTimerRef = useRef(null);
+
+  // (예시) 시선 라벨 추정 함수 — 실제 모델 함수로 교체
+  const getGazeLabel = () => {
+    // return window.__gaze?.getLabel(videoRef.current) ?? null;
+    return "center";
+  };
+
   useEffect(() => {
     (async () => {
       try {
@@ -55,31 +76,97 @@ export default function InterviewSessionPage() {
         streamRef.current = stream;
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
-          // 일부 브라우저는 autoplay 속성만으론 부족해서 play() 호출 필요
           await videoRef.current.play().catch(() => {});
         }
+        setCamReady(true);
+        startIntro();
       } catch (err) {
         console.error("웹캠 접근 실패:", err);
+        setCamError(true);
+        setCamReady(false);
+        startIntro(); // 권한 전까지는 인식 대기 상태 유지
       }
     })();
     return () => {
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((t) => t.stop());
-      }
+      clearInterval(timerRef.current);
+      clearInterval(sampleTimerRef.current);
+      clearTimeout(introTimerRef.current);
+      if (streamRef.current) streamRef.current.getTracks().forEach((t) => t.stop());
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // ===== 인트로: 라벨 샘플링 + (조건 충족 시) 카운트다운 시작 =====
+  const startIntro = () => {
+    setPhase("intro");
+    setIsRunning(false);
+    setIntroLeft(INTRO_SECONDS);
+    setFaceReady(false);
+    introStartedRef.current = false;
+    gazeSamplesRef.current = [];
+
+    // 10Hz로 라벨 수집 + 얼굴 인식 판단
+    clearInterval(sampleTimerRef.current);
+    let consecutive = 0; // 연속 인식 카운트
+    sampleTimerRef.current = setInterval(() => {
+      const label = getGazeLabel();
+      if (label) {
+        gazeSamplesRef.current.push(label);
+        consecutive += 1;
+      } else {
+        consecutive = 0;
+      }
+      // 약 0.8초 이상 연속 인식되면 faceReady로 판단
+      if (!faceReady && consecutive >= 8) {
+        setFaceReady(true);
+      }
+    }, 100);
+  };
+
+  // 얼굴/카메라가 준비되면 카운트다운 시작
+  useEffect(() => {
+    if (phase !== "intro") return;
+    if (!camReady || !faceReady) return;
+    if (introStartedRef.current) return;
+
+    introStartedRef.current = true;
+
+    const runTimer = (time) => {
+      if (time <= 0) {
+        finishIntro();
+        return;
+      }
+      setIntroLeft(time);
+      introTimerRef.current = setTimeout(() => runTimer(time - 1), 1000);
+    };
+    runTimer(INTRO_SECONDS);
+  }, [camReady, faceReady, phase]);
+
+  const finishIntro = () => {
+    clearInterval(sampleTimerRef.current);
+    const counts = gazeSamplesRef.current.reduce((acc, l) => {
+      acc[l] = (acc[l] || 0) + 1;
+      return acc;
+    }, {});
+    const baseline =
+      Object.keys(counts).length > 0
+        ? Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0]
+        : "center";
+    baselineRef.current = baseline;
+
+    setPhase("question");
+    setIsRunning(true);
+  };
+
+  // ===== 질문 완료/진행 =====
   const handleComplete = () => {
     setIsRunning(false);
     if (index < questions.length - 1) {
-      // 다음 질문으로
       setIndex((i) => i + 1);
       setSecondsLeft(ANSWER_SECONDS);
       setIsRunning(true);
     } else {
-      // 모든 질문 완료
       alert("모든 질문이 완료되었습니다.");
-      // 결과 페이지가 있다면 아래 주석 해제해서 사용
       // navigate("/interview/result", { state: { job, questions } });
     }
   };
@@ -101,21 +188,35 @@ export default function InterviewSessionPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRunning, index]);
 
+  // 인트로 상태 텍스트/배지
+  const status = camError
+    ? { kind: "error", text: "카메라 권한이 필요합니다. 브라우저 팝업을 허용하세요." }
+    : !camReady
+    ? { kind: "warn", text: "카메라 연결 중…" }
+    : faceReady
+    ? { kind: "ok", text: "카메라 인식 완료! 자세를 유지해주세요." }
+    : { kind: "warn", text: "얼굴을 프레임 중앙에 맞춰주세요." };
+
   return (
     <div className={styles.page}>
-      {/* 흰색 둥근 카드 래퍼 */}
       <section className={styles.content}>
         <div className={styles.card}>
-          {/* 상단 카테고리(회색 캡슐) */}
+          {/* 카테고리 캡슐 */}
           <div className={styles.categoryWrapper}>
             <span className={styles.categoryLabel}>{job}</span>
           </div>
 
-          {/* 배지(진행도) + 타이틀(질문) */}
+          {/* 인트로: 안내 / 질문 단계: 실제 질문 */}
           <PageHero
             className={styles.heroOverride}
-            badge={`${index + 1}/${questions.length}`}
-            title={currentQuestion}
+            badge={
+              phase === "question" ? `${index + 1}/${questions.length}` : "준비"
+            }
+            title={
+              phase === "question"
+                ? currentQuestion
+                : "카메라를 5초간 응시해주세요"
+            }
             maxWidth={960}
           />
 
@@ -130,12 +231,99 @@ export default function InterviewSessionPage() {
                   playsInline
                   muted
                 />
+
+                {/* 인트로 오버레이 (얼굴 마스크 + 가이드라인 + 상태 + 카운트다운) */}
+                {phase === "intro" && (
+                  <div className={styles.overlay} role="dialog" aria-modal="true">
+                    {/* SVG defs: 얼굴 마스크 정의 */}
+                    <svg className={styles.hiddenSvg} width="0" height="0" aria-hidden>
+                      <defs>
+                        <mask id="faceMask" maskUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
+                          <rect x="0" y="0" width="100%" height="100%" fill="black" />
+                          {/* 가로를 약간 키웠습니다(rx 30%) */}
+                          <ellipse cx="50%" cy="42%" rx="30%" ry="36%" fill="white" />
+                          <path
+                            d="
+                              M 20% 56%
+                              C 34% 78%, 66% 78%, 80% 56%
+                              C 74% 84%, 26% 84%, 20% 56%
+                            "
+                            fill="white"
+                            opacity="0.85"
+                          />
+                        </mask>
+                      </defs>
+                    </svg>
+
+                    {/* 블러 + 딤(마스크로 얼굴 부분만 투명) */}
+                    <div className={styles.overlayFace} aria-hidden />
+
+                    {/* 얼굴 가이드라인(SVG) */}
+                    <svg className={styles.faceGuides} viewBox="0 0 1000 1400" aria-hidden>
+                      {/* 외곽 윤곽선(가이드) */}
+                      <path
+                        d="M280,520 C280,350 410,240 500,240 C590,240 720,350 720,520 C720,780 630,990 500,1060 C370,990 280,780 280,520 Z"
+                        className={styles.faceLine}
+                      />
+
+                      {/* 눈 가이드 (좌/우) */}
+                      <ellipse cx="400" cy="560" rx="80" ry="28" className={styles.eyeLine}/>
+                      <ellipse cx="600" cy="560" rx="80" ry="28" className={styles.eyeLine}/>
+                      {/* 눈썹 가이드 */}
+                      <path d="M330,520 Q410,495 490,520" className={styles.browLine}/>
+                      <path d="M510,520 Q590,495 670,520" className={styles.browLine}/>
+
+                      {/* 코 가이드 */}
+                      <path d="M500,560 L500,700" className={styles.noseLine}/>
+                      <path d="M455,720 Q500,740 545,720" className={styles.noseBase}/>
+
+                      {/* 입 가이드 */}
+                      <path d="M410,800 Q500,830 590,800" className={styles.mouthLine}/>
+                      <path d="M420,800 Q500,820 580,800" className={styles.mouthInner}/>
+
+                      {/* 가운데 정렬 보조선(얇게) */}
+                      <line x1="500" y1="280" x2="500" y2="1040" className={styles.centerLine}/>
+                    </svg>
+
+                    {/* 상태 배지 + 안내 + 카운트다운 */}
+                    <div className={styles.overlayBox}>
+                      <div className={`${styles.statusPill} ${styles[status.kind]}`}>
+                        <span className={styles.dot} />
+                        {status.text}
+                      </div>
+
+                      <div className={styles.overlayTitle}>시선 기준점 설정</div>
+                      <p className={styles.overlayDesc}>
+                        카메라가 인식되면 5초 카운트다운이 시작됩니다.
+                        <br />
+                        얼굴이 윤곽선 안에 들어오도록 맞추고 렌즈를 바라봐 주세요.
+                      </p>
+
+                      {/* 카운트다운: 준비되기 전에는 흐리게 */}
+                      <div
+                        className={`${styles.countdownTop} ${
+                          camReady && faceReady ? "" : styles.countdownDim
+                        }`}
+                        aria-live="polite"
+                      >
+                        {introLeft}
+                      </div>
+
+                      {/* 권한 오류 시 보조 안내 */}
+                      {camError && (
+                        <div className={styles.permissionHelp}>
+                          브라우저 주소창의 카메라 아이콘을 눌러 접근을 허용해 주세요.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
 
             {/* Right: Timer & Controls */}
             <div className={styles.rightCol}>
-              <div className={styles.timerWrap}>
+              <div className={styles.timerWrap} aria-hidden={phase !== "question"}>
                 <svg width="320" height="320" aria-hidden>
                   <circle
                     cx="160"
@@ -169,10 +357,15 @@ export default function InterviewSessionPage() {
                 <Button
                   className={styles.primaryBtn}
                   onClick={() => setIsRunning((r) => !r)}
+                  disabled={phase !== "question"}
                 >
                   {isRunning ? "일시정지" : "다시 시작"}
                 </Button>
-                <Button className={styles.secondaryBtn} onClick={handleComplete}>
+                <Button
+                  className={styles.secondaryBtn}
+                  onClick={handleComplete}
+                  disabled={phase !== "question"}
+                >
                   완료
                 </Button>
               </div>

--- a/src/pages/Interview/InterviewSessionPage.module.css
+++ b/src/pages/Interview/InterviewSessionPage.module.css
@@ -1,3 +1,5 @@
+/* File: src/pages/Interview/InterviewSessionPage.module.css */
+
 .page {
   padding: 24px;
   background: #f7faff;
@@ -34,16 +36,13 @@
   box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   word-break: keep-all;
   overflow-wrap: anywhere;
-  /* 카테고리-배지 간격은 PageHero padding으로 통제하므로 margin 생략 */
 }
 
-/* PageHero 오버라이드(이 페이지 한정) — padding: 20 16 20 */
+/* PageHero 오버라이드(이 페이지 한정) */
 .heroOverride:global(.page-hero) {
   padding: 20px 16px 35px !important;
   margin-top: 0 !important;
 }
-
-/* 배지/타이틀 세부 조정 */
 .heroOverride :global(.page-hero__badge) {
   font-size: 17px;
   height: 44px;
@@ -67,6 +66,7 @@
   align-items: start;
 }
 .videoWrap {
+  position: relative; /* 오버레이가 올라오도록 */
   width: 100%;
   aspect-ratio: 16/10;
   border-radius: 16px;
@@ -123,7 +123,7 @@
   opacity: 0.95;
 }
 
-/* 버튼: 페이지 한정 스타일 */
+/* 버튼 */
 .buttons {
   display: grid;
   gap: 14px;
@@ -131,8 +131,6 @@
   width: 100%;
   justify-items: center;
 }
-
-/* 텍스트 가독성 보장 */
 .primaryBtn,
 .secondaryBtn {
   display: inline-flex;
@@ -141,8 +139,6 @@
   gap: 8px;
   -webkit-text-fill-color: currentColor !important;
 }
-
-/* primary (다시 시작) */
 .primaryBtn {
   width: 300px;
   height: 50px;
@@ -156,8 +152,6 @@
   box-shadow: 0 6px 14px rgba(0,0,0,0.2);
   border: none;
 }
-
-/* secondary (완료) */
 .secondaryBtn {
   width: 300px;
   height: 50px;
@@ -171,18 +165,6 @@
   border-radius: 22px;
   box-shadow: 0 6px 14px rgba(0,0,0,0.08);
 }
-
-/* 버튼 내부 어떤 요소라도 텍스트 상속 강제 */
-.primaryBtn * ,
-.secondaryBtn * {
-  color: inherit !important;
-  font-size: inherit !important;
-  font-weight: inherit !important;
-  line-height: 1.1 !important;
-  -webkit-text-fill-color: currentColor !important;
-}
-
-/* 상호작용 */
 .primaryBtn:hover { filter: brightness(1.1); }
 .secondaryBtn:hover { background: #f5f7fa; }
 .primaryBtn:focus-visible,
@@ -193,14 +175,177 @@
 .primaryBtn:active,
 .secondaryBtn:active { transform: translateY(1px); }
 
-/* 반응형 */
 @media (max-width: 960px) {
   .container { grid-template-columns: 1fr; }
-  .timerWrap { width: 280px; height: 280px; } /* 모바일에서 더 축소 */
+  .timerWrap { width: 280px; height: 280px; }
   .primaryBtn, .secondaryBtn {
     width: 100%;
     max-width: 480px;
     height: 60px;
     font-size: 18px;
   }
+}
+
+/* ===== Intro Overlay ===== */
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 2;
+}
+
+/* 숨김용 SVG(defs 전용) */
+.hiddenSvg {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+/* 블러 + 딤, 얼굴 영역만 투명(마스크) */
+.overlayFace {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 14, 22, 0.45);
+  backdrop-filter: blur(8px) saturate(0.9);
+  mask: url(#faceMask);
+  -webkit-mask: url(#faceMask);
+}
+
+/* 얼굴 가이드라인 */
+.faceGuides {
+  position: absolute;
+  inset: 0;
+  width: min(52vw, 520px);   /* 가로 더 키움 */
+  height: min(70vh, 580px);
+  left: 50%;
+  top: 46%;
+  transform: translate(-50%, -46%);
+  pointer-events: none;
+}
+
+/* 라인 스타일 */
+.faceLine {
+  fill: none;
+  stroke: rgba(255,255,255,0.65);
+  stroke-width: 3;
+}
+.eyeLine {
+  fill: none;
+  stroke: rgba(255,255,255,0.9);
+  stroke-width: 2.5;
+}
+.browLine {
+  fill: none;
+  stroke: rgba(255,255,255,0.5);
+  stroke-width: 2;
+}
+.noseLine {
+  fill: none;
+  stroke: rgba(255,255,255,0.8);
+  stroke-width: 2;
+}
+.noseBase {
+  fill: none;
+  stroke: rgba(255,255,255,0.7);
+  stroke-width: 2;
+}
+.mouthLine {
+  fill: none;
+  stroke: rgba(255,255,255,0.85);
+  stroke-width: 2.4;
+}
+.mouthInner {
+  fill: none;
+  stroke: rgba(255,255,255,0.5);
+  stroke-width: 1.6;
+}
+.centerLine {
+  stroke: rgba(255,255,255,0.25);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 8;
+}
+
+/* 안내 카드 */
+.overlayBox {
+  position: relative;
+  width: min(92%, 560px);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #dfe6f5;
+  border-radius: 20px;
+  box-shadow: 0 12px 28px rgba(15, 27, 51, 0.25);
+  padding: 24px 22px 22px;
+  text-align: center;
+}
+
+/* 상태 배지 */
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 800;
+  font-size: 14px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  margin-bottom: 8px;
+}
+.statusPill .dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(255,255,255,0.5) inset;
+}
+.ok { background: rgba(56, 196, 137, 0.18); color: #0a7f52; border: 1px solid rgba(56,196,137,0.35); }
+.ok .dot { background: #38c489; }
+.warn { background: rgba(255, 200, 80, 0.2); color: #9c6c00; border: 1px solid rgba(255,200,80,0.4); }
+.warn .dot { background: #ffc850; animation: blink 1.2s infinite; }
+.error { background: rgba(244, 85, 85, 0.18); color: #9b1c1c; border: 1px solid rgba(244,85,85,0.35); }
+.error .dot { background: #f45555; }
+
+@keyframes blink {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+.overlayTitle {
+  font-weight: 800;
+  font-size: 18px;
+  color: #0f1b33;
+  margin-bottom: 6px;
+  letter-spacing: 0.2px;
+}
+.overlayDesc {
+  color: #2f3b57;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 0 auto 10px;
+}
+.permissionHelp {
+  margin-top: 10px;
+  font-size: 13px;
+  color: #8b96b2;
+}
+
+/* 카운트다운: 상단 고정 */
+.countdownTop {
+  font-weight: 900;
+  font-size: clamp(48px, 8vw, 72px);
+  line-height: 1;
+  color: #ffffff;
+  text-shadow: 0 2px 6px rgba(0,0,0,0.25);
+  position: absolute;
+  top: -10%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  letter-spacing: -2px;
+  transition: opacity .25s ease;
+}
+.countdownDim { opacity: 0.35; }
+
+/* overlay 위 버튼 크기 조정 (현재 버튼 없음이 기본) */
+.overlay .secondaryBtn {
+  min-width: 132px;
+  height: 42px;
+  font-size: 15px;
+  border-radius: 12px;
 }


### PR DESCRIPTION
## 작업 내용
- AI 면접 세션 화면에 얼굴 마스크 및 눈·코·입 가이드라인 추가
- 가이드라인은 눈 2점, 코 1점, 입 1점 기준으로 시선 분석 참고 가능
- CSS에서 계란형 border-radius 적용 + 오버레이 마스크 구현

## 변경 사항
- `InterviewSessionPage.jsx` 수정
  - 오버레이 컴포넌트 및 SVG 마스크 추가
- `InterviewSessionPage.module.css` 수정
  - 계란형 얼굴 마스크 및 가이드라인 스타일 정의

## 관련 이슈
Closes #18 
<img width="1237" height="671" alt="스크린샷 2025-08-18 오전 12 26 26" src="https://github.com/user-attachments/assets/c19a792f-7cd1-4a1a-8dc5-8c86544a2e49" />


## 기타
- 추후 gaze scoring 로직과 연결 필요
- 마스크 크기/위치 조정 가능 (실 사용자 테스트 예정)
