### PR TITLE
[Feat] AptitudeTestPage: 인적성 검사 페이지 추가 및 라우터 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,8 @@ import InterviewSessionPage from './pages/Interview/InterviewSessionPage';
 import SelfIntroPage from './pages/SelfIntro/SelfIntroPage';
 import AiSelfIntroPage from './pages/SelfIntro/AiSelfIntroPage';
 
+import AptitudeTestPage from './pages/AptitudeTest/AptitudeTestPage';
+
 // 👉 새로 만든 MainPage import
 import MainPage from './pages/MainPage/MainPage';
 
@@ -31,6 +33,7 @@ function App() {
 
           <Route path="/mypage" element={<BasicInfoPage />} />
           <Route path="/interview-prep" element={<InterviewPrepPage />} />
+    
 
           {/* 기존 페이지들도 필요시 유지 */}
           <Route path="/ai-interview" element={<CategorySelect />} />
@@ -38,6 +41,8 @@ function App() {
           <Route path="/interview/session" element={<InterviewSessionPage />} />
           <Route path="/selfintro" element={<SelfIntroPage />} />
           <Route path="/ai-selfintro" element={<AiSelfIntroPage />} />
+          <Route path="/aptitude" element={<AptitudeTestPage />} />
+
         </Routes>
       </main>
     </Router>

--- a/src/pages/AptitudeTest/AptitudeTestPage.jsx
+++ b/src/pages/AptitudeTest/AptitudeTestPage.jsx
@@ -1,0 +1,168 @@
+import React, { useMemo, useState } from "react";
+import PageHero from "../../components/Common/PageHero";
+import Button from "../../components/Common/Button";
+import styles from "./AptitudeTestPage.module.css";
+
+/** 스텝 정의 */
+const STEP = { SELECT: 1, PREP: 2, TEST: 3, RESULT: 4 };
+/** 검사 유형 */
+const TYPES = { BIG5: "big5", JOB: "job" };
+
+const GUIDE_TEXT = {
+  [TYPES.BIG5]: `Big 5 성격 검사는 개인의 성격을 다섯 가지 핵심 요인 (개방성, 성실성, 외향성, 우호성, 신경성)으로 측정하여 성격 프로파일을 파악하는 검사입니다.
+
+📌 검사 전 유의사항
+- 검사 시간은 약 10~15분 정도 소요됩니다.
+- 정답은 없으며, 평소 자신의 생각과 행동에 가장 가까운 답변을 선택하세요.
+- 일관성 있게, 솔직하게 응답하는 것이 가장 중요합니다.
+- 집중할 수 있는 조용한 환경에서 검사에 참여해주세요.
+- 인터넷 연결이 안정적인 환경에서 진행해주세요.
+
+검사 결과는 개인의 성향을 이해하고 직무 적합성을 평가하는 데 참고 자료로 활용됩니다.`,
+
+  [TYPES.JOB]: `직무 성향 검사는 특정 직무를 수행할 때 요구되는 행동·사고 성향을 평가합니다.
+(문제 해결/분석력, 대인관계·협업 성향, 책임감·규율성, 성과지향, 변화 수용 등)
+
+📌 검사 전 유의사항
+- 검사 시간은 약 10~15분 정도 소요됩니다.
+- 정답은 없으며, 평소 자신의 생각과 행동에 가장 가까운 답변을 선택하세요.
+- 일관성 있게, 솔직하게 응답하는 것이 가장 중요합니다.
+- 집중할 수 있는 조용한 환경에서 검사에 참여해주세요.
+- 인터넷 연결이 안정적인 환경에서 진행해주세요.
+
+검사 결과는 지원 직무와의 적합도를 파악하고 강·약점을 이해하는 데 참고 자료로 활용됩니다.`,
+};
+
+export default function AptitudeTestPage() {
+  const [step, setStep] = useState(STEP.SELECT);
+  const [type, setType] = useState(null); // "big5" | "job"
+
+  /** 상단 리본 타이틀 */
+  const ribbonTitle = useMemo(() => {
+    if (!type) return "";
+    return type === TYPES.BIG5 ? "Big 5 검사 (성격 5요인 검사)" : "직무 성향 검사";
+  }, [type]);
+
+  const canNext = useMemo(() => {
+    if (step === STEP.SELECT) return !!type;
+    // TODO: 이후 단계 유효성 검증 필요 시 조건 추가
+    return true;
+  }, [step, type]);
+
+  const goNext = () => {
+    if (!canNext) return;
+    setStep((s) => Math.min(STEP.RESULT, s + 1));
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const goBack = () => {
+    setStep((s) => Math.max(STEP.SELECT, s - 1));
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <div className={styles.page}>
+      {/* 히어로 (이 페이지에서만 padding 오버라이드 가능) */}
+      <PageHero
+        className={styles.heroOverride}
+        badge="인적성 검사"
+        title="개인의 성격과 직무 적합성을 종합적으로 평가합니다."
+        maxWidth={1200}
+      />
+
+      {/* 스텝 네비게이션 */}
+      <ol className={styles.stepper}>
+        <li className={step >= STEP.SELECT ? styles.stepActive : ""}>step1. 검사 유형 선택</li>
+        <li className={step >= STEP.PREP ? styles.stepActive : ""}>step2. 검사 준비/안내</li>
+        <li className={step >= STEP.TEST ? styles.stepActive : ""}>step3. 검사 진행</li>
+        <li className={step >= STEP.RESULT ? styles.stepActive : ""}>step4. 검사 종료/결과 확인</li>
+      </ol>
+
+      {/* step1: 검사 유형 선택 */}
+      {step === STEP.SELECT && (
+        <section className={styles.section}>
+          <div className={styles.cardGrid}>
+            <button
+              type="button"
+              className={`${styles.card} ${type === TYPES.BIG5 ? styles.cardActive : ""}`}
+              onClick={() => setType(TYPES.BIG5)}
+            >
+              <h3 className={styles.cardTitle}>Big 5 검사 (성격 5요인 검사)</h3>
+              <p className={styles.cardBody}>
+                개인의 성격 특성을 다섯 가지 핵심 요인으로 평가합니다.<br />
+                측정 영역은 개방성, 성실성, 외향성, 우호성, 신경성입니다. 개인의 전반적인 성격<br />
+                프로파일을 확인해 팀워크 적합도, 리더십 잠재력, 직무 적응력 등을 간접적으로<br />
+                예측할 수 있습니다.
+              </p>
+            </button>
+
+            <button
+              type="button"
+              className={`${styles.card} ${type === TYPES.JOB ? styles.cardActive : ""}`}
+              onClick={() => setType(TYPES.JOB)}
+            >
+              <h3 className={styles.cardTitle}>직무 성향 검사 (직무 적합도)</h3>
+              <p className={styles.cardBody}>
+                특정 직무에 얼마나 잘 맞는 성향을 갖추고 있는지 평가합니다.<br />
+                측정 영역은 문제 해결 및 분석력, 대인 관계/협력 성향, 책임감/규율성,<br />
+                성과 지향성, 변화 수용력입니다. 지원자가 가진 성격과 행동 성향이 측정 직부의<br />
+                요구사항과 잘 맞는지를 확인할 수 있습니다.
+              </p>
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* 리본 (step2~) */}
+      {step >= STEP.PREP && (
+        <div className={styles.section}>
+            <div className={styles.ribbon}>{ribbonTitle}</div>
+        </div>
+        )}
+
+
+      {/* step2: 안내 */}
+      {step === STEP.PREP && (
+        <section className={styles.section}>
+            <div className={styles.field}>
+                <span>검사 안내</span>
+                <div className={styles.textarea} style={{whiteSpace: "pre-line"}}>
+                    {GUIDE_TEXT[type]}
+                </div>
+            </div>
+        </section>
+      )}
+
+      {/* step3: 검사 진행 (플레이스홀더) */}
+      {step === STEP.TEST && (
+        <section className={styles.section}>
+          <div className={styles.testBox}>
+            <p className={styles.placeholder}>
+              이곳에 문항 컴포넌트/타이머/진행 바 등을 연결하세요. (후속 작업)
+            </p>
+          </div>
+        </section>
+      )}
+
+      {/* step4: 임시 결과 */}
+      {step === STEP.RESULT && (
+        <section className={styles.section}>
+          <div className={styles.resultBox}>
+            <h3>임시 결과 화면</h3>
+            <p>채점/그래프/리포트 다운로드는 이후 단계에서 연결합니다.</p>
+          </div>
+        </section>
+      )}
+
+      {/* 하단 버튼 */}
+      <div className={styles.footer}>
+        <Button className={styles.secondaryBtn} onClick={goBack} disabled={step === STEP.SELECT}>
+          Back
+        </Button>
+        <Button className={styles.primaryBtn} onClick={goNext} disabled={!canNext}>
+          Next step
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AptitudeTest/AptitudeTestPage.module.css
+++ b/src/pages/AptitudeTest/AptitudeTestPage.module.css
@@ -1,0 +1,159 @@
+.page {
+  background: #ebf5fd;
+  min-height: 100vh;
+  font-family: "Pretendard Variable", sans-serif;
+}
+
+/* 히어로 오버라이드: 이 페이지에서만 padding 수정 */
+
+
+/* 스텝 네비게이션 */
+.stepper {
+  max-width: 1200px;
+  margin: 10px auto 20px;
+  padding: 0 16px 14px;
+  display: flex;
+  gap: 40px; 
+  border-bottom: 1px solid #d1d5db;
+  list-style: none;
+  font-family: "Pretendard Variable", sans-serif;
+  justify-content: center; 
+}
+.stepper li {
+  font-size: 18px;
+  color: #6b7280;
+}
+.stepActive {
+  color: #1f2a44;
+  font-weight: 900;
+}
+
+/* 공통 섹션 */
+.section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 16px 16px;
+  font-family: "Pretendard Variable", sans-serif;
+}
+
+/* 카드 선택 (step1) */
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+.card {
+  background: #ffffff;
+  border: 2px solid #e6ebf4;
+  border-radius: 16px;
+  padding: 40px;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(20, 30, 60, 0.08);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.05s ease;
+  font-family: "Pretendard Variable", sans-serif;
+}
+.card:hover { box-shadow: 0 10px 24px rgba(20,30,60,0.12); }
+.card:active { transform: translateY(1px); }
+.cardActive { border-color: #3b82f6; box-shadow: 0 0 0 3px rgba(59,130,246,.25); }
+.cardTitle { margin: 0 0 20px; font-size: 20px; color: #1f2a44; font-weight: 800; }
+.cardBody { margin: 0; font-size: 16px; color: #374151; line-height: 1.6; }
+
+/* 리본 (step2~) */
+.ribbon {
+  max-width: 1200px;
+  margin: 16px auto 10px;
+  padding: 12px 16px;
+  background: #322d52;
+  color: #fff;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: 700;
+  font-family: "Pretendard Variable", sans-serif;
+  text-align: left;
+  
+}
+
+/* 입력 필드 */
+.field {
+  display: grid;
+  gap: 18px;
+  font-family: "Pretendard Variable", sans-serif;
+}
+.field > span {
+  font-size: 20px;
+  color: #3a4669;
+  font-weight: 800;
+  text-align: center;
+  margin-top: 40px;
+}
+.textarea {
+  border: 1.5px solid #d7def0;
+  border-radius: 12px;
+  padding: 40px 16px;
+  min-height: 200px;
+  font-size: 17px;
+  background: #fff;
+  outline: none;
+  font-weight: 500;
+  font-family: "Pretendard Variable", sans-serif;
+  line-height: 1.4;
+}
+.textarea:focus { border-color: #3b82f6; box-shadow: 0 0 0 3px rgba(59,130,246,.15); }
+.textarea::placeholder {
+  font-family: "Pretendard Variable", sans-serif; 
+}
+/* 검사/결과 박스 (플레이스홀더) */
+.testBox, .resultBox {
+  border: 2px dashed #c7cdd4;
+  border-radius: 12px;
+  min-height: 320px;
+  background: #f9fafb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.placeholder { color: #6b7280; font-family: "Pretendard Variable", sans-serif;}
+
+/* 하단 버튼 */
+.footer {
+  max-width: 1200px;
+  margin: 18px auto 60px;
+  padding: 0 16px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  font-family: "Pretendard Variable", sans-serif;
+}
+
+/* 공통 버튼 오버라이드(프로젝트 공통 Button에 className으로 적용) */
+.primaryBtn {
+  width: 150px;
+  height: 50px;
+  font-size: 18px;
+  font-weight: 800;
+  background: #3b3450;
+  color: #ffffff !important;
+  border: none;
+  border-radius: 28px;
+  font-family: "Pretendard Variable", sans-serif;
+}
+.primaryBtn:disabled { opacity: .5; cursor: not-allowed; }
+
+.secondaryBtn {
+  width: 150px;
+  height: 50px;
+  font-size: 18px;
+  font-weight: 800;
+  background: #ffffff;
+  color: #0f1b33 !important;
+  border: 2px solid #a0acc7;
+  border-radius: 28px;
+  font-family: "Pretendard Variable", sans-serif;
+}
+.secondaryBtn:disabled { opacity: .5; cursor: not-allowed; }
+
+/* 반응형 */
+@media (max-width: 960px) {
+  .cardGrid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
### - 변경 요약
인적성 검사 신규 페이지 추가 
단계 진행(SELECT → PREP → TEST → RESULT) 로직 구현
검사 유형 2종 선택: Big 5(성격 5요인) / 직무 성향
선택된 유형에 따라 리본 타이틀과 안내문 표시
공통 PageHero 사용 + 히어로/리본/스텝퍼/카드/버튼 스타일 적용

### - 테스트 방법
로컬 실행 후 /aptitude 접속
step1에서 카드 클릭으로 검사 유형 선택 (선택 시 카드 액티브 스타일 확인)
Next step (step2 이동)
상단 리본에 선택한 유형 문구 반영 확인
Back / Next step 버튼으로 단계 전환 확인(step3/4)

### - 스크린샷

step 1
<img width="1568" height="594" alt="스크린샷 2025-08-24 183828" src="https://github.com/user-attachments/assets/32c4625a-5e8e-4773-a6cc-e9f905a96e14" />

step2
<img width="1362" height="768" alt="스크린샷 2025-08-24 183904" src="https://github.com/user-attachments/assets/721e503d-bd30-4829-923b-208a93b07b8b" />

step3
<img width="1396" height="743" alt="스크린샷 2025-08-24 183916" src="https://github.com/user-attachments/assets/c9d79efe-c2ab-4a6f-aa95-fc41d01dfc12" />

step4
<img width="1388" height="729" alt="스크린샷 2025-08-24 183927" src="https://github.com/user-attachments/assets/992dd0a7-dd5e-4d27-8253-28102bffd1da" />


